### PR TITLE
feat: Add Multiplatform Settings and Migrate Existing Settings

### DIFF
--- a/Multiplatform Roadmap.md
+++ b/Multiplatform Roadmap.md
@@ -36,12 +36,13 @@ multiplatform this project grows stronger and stronger.
 
 - [ ] Models and FavoritesDatabase can be converted to multiplatform now
   - [x] FavoritesDatabase
+  - [x] Datastore
+    - [ ] Protobuf - in progress
+    - [ ] Need to figure out specific apps protobuf. Might need a later change.
   - [ ] Models
     - Uses some Java libraries, so need to figure out a way to keep some of that while also not
       affecting any other sources
 - [ ] Screens that do not have m3 alpha components can go into a multiplatform module
-- [ ] Move datastore components to a multiplatform module?
-    - [ ] Maybe it goes into the same one with that goes in that's above?
 - [ ] Start removal of gson
 - [ ] ViewModels could probably be moved into the kmp module
 

--- a/UIViews/src/main/java/com/programmersbox/uiviews/BaseMainActivity.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/BaseMainActivity.kt
@@ -115,6 +115,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.programmersbox.datastore.DataStoreHandling
+import com.programmersbox.datastore.NewSettingsHandling
 import com.programmersbox.datastore.rememberFloatingNavigation
 import com.programmersbox.extensionloader.SourceRepository
 import com.programmersbox.favoritesdatabase.ItemDatabase
@@ -122,7 +123,6 @@ import com.programmersbox.favoritesdatabase.SourceOrder
 import com.programmersbox.sharedutils.AppLogo
 import com.programmersbox.sharedutils.AppUpdate
 import com.programmersbox.sharedutils.updateAppCheck
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.presentation.Screen
 import com.programmersbox.uiviews.presentation.components.HazeScaffold
 import com.programmersbox.uiviews.presentation.components.MultipleActions
@@ -168,7 +168,7 @@ abstract class BaseMainActivity : AppCompatActivity() {
 
     protected fun isNavInitialized() = ::navController.isInitialized
 
-    private val settingsHandling: SettingsHandling by inject()
+    private val settingsHandling: NewSettingsHandling by inject()
 
     private val sourceRepository by inject<SourceRepository>()
     private val currentSourceRepository by inject<CurrentSourceRepository>()

--- a/UIViews/src/main/java/com/programmersbox/uiviews/BaseMainActivity.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/BaseMainActivity.kt
@@ -370,10 +370,10 @@ abstract class BaseMainActivity : AppCompatActivity() {
         currentDestination: NavDestination?,
         showBlur: Boolean,
         isAmoledMode: Boolean,
-        middleNavItem: MiddleNavigationAction,
+        middleNavItem: com.programmersbox.datastore.MiddleNavigationAction,
         modifier: Modifier = Modifier,
         scrollBehavior: BottomAppBarScrollBehavior? = null,
-        multipleActions: MiddleMultipleActions,
+        multipleActions: com.programmersbox.datastore.MiddleMultipleActions?,
     ) {
         val scope = rememberCoroutineScope()
         AnimatedVisibility(
@@ -480,13 +480,15 @@ abstract class BaseMainActivity : AppCompatActivity() {
                     )
                 }
 
-                MultipleActions(
-                    state = multipleBarState,
-                    middleNavItem = middleNavItem,
-                    multipleActions = multipleActions,
-                    currentDestination = currentDestination,
-                    navController = navController
-                )
+                multipleActions?.let {
+                    MultipleActions(
+                        state = multipleBarState,
+                        middleNavItem = middleNavItem,
+                        multipleActions = it,
+                        currentDestination = currentDestination,
+                        navController = navController
+                    )
+                }
             }
         }
     }
@@ -499,8 +501,8 @@ abstract class BaseMainActivity : AppCompatActivity() {
         currentDestination: NavDestination?,
         showBlur: Boolean,
         isAmoledMode: Boolean,
-        middleNavItem: MiddleNavigationAction,
-        multipleActions: MiddleMultipleActions,
+        middleNavItem: com.programmersbox.datastore.MiddleNavigationAction,
+        multipleActions: com.programmersbox.datastore.MiddleMultipleActions?,
         modifier: Modifier = Modifier,
     ) {
         val scope = rememberCoroutineScope()
@@ -573,13 +575,15 @@ abstract class BaseMainActivity : AppCompatActivity() {
                 }
             }
 
-            MultipleActions(
-                state = multipleBarState,
-                middleNavItem = middleNavItem,
-                multipleActions = multipleActions,
-                currentDestination = currentDestination,
-                navController = navController
-            )
+            multipleActions?.let {
+                MultipleActions(
+                    state = multipleBarState,
+                    middleNavItem = middleNavItem,
+                    multipleActions = it,
+                    currentDestination = currentDestination,
+                    navController = navController
+                )
+            }
         }
     }
 

--- a/UIViews/src/main/java/com/programmersbox/uiviews/OtakuApp.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/OtakuApp.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.datastore.preferences.core.edit
 import androidx.work.Configuration
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -34,7 +33,6 @@ import com.programmersbox.datastore.DataStoreHandling
 import com.programmersbox.datastore.DataStoreSettings
 import com.programmersbox.datastore.NewSettingsHandling
 import com.programmersbox.datastore.createProtobuf
-import com.programmersbox.datastore.otakuDataStore
 import com.programmersbox.extensionloader.SourceLoader
 import com.programmersbox.favoritesdatabase.CustomListItem
 import com.programmersbox.favoritesdatabase.ListDatabase
@@ -52,7 +50,6 @@ import com.programmersbox.uiviews.checkers.UpdateNotification
 import com.programmersbox.uiviews.datastore.OtakuDataStoreHandling
 import com.programmersbox.uiviews.datastore.RemoteConfigKeys
 import com.programmersbox.uiviews.datastore.SettingsHandling
-import com.programmersbox.uiviews.datastore.dataStore
 import com.programmersbox.uiviews.datastore.migrateSettings
 import com.programmersbox.uiviews.di.databases
 import com.programmersbox.uiviews.di.repository
@@ -174,14 +171,10 @@ abstract class OtakuApp : Application(), Configuration.Provider {
         val newSettingsHandling = get<NewSettingsHandling>()
         val settingsHandling = get<SettingsHandling>()
 
-        //TODO: Make sure this only happens once
-        dataStore
-            .data
-            .onEach { old -> otakuDataStore.edit { new -> new += old } }
-            .launchIn(GlobalScope)
-
         //TODO: Remove the migration after the next full release
         migrateSettings(
+            context = this,
+            dataStoreHandling = dataStoreHandling,
             settingsHandling = settingsHandling,
             newSettingsHandling = newSettingsHandling
         )

--- a/UIViews/src/main/java/com/programmersbox/uiviews/datastore/RemoteConfigKeys.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/datastore/RemoteConfigKeys.kt
@@ -2,6 +2,7 @@ package com.programmersbox.uiviews.datastore
 
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.programmersbox.datastore.DataStoreHandling
+import com.programmersbox.datastore.NewSettingsHandling
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.serialization.json.Json
 
@@ -14,6 +15,7 @@ enum class RemoteConfigKeys(val key: String) {
         dataStoreHandling: DataStoreHandling,
         otakuDataStoreHandling: OtakuDataStoreHandling,
         settingsHandling: SettingsHandling,
+        newSettingsHandling: NewSettingsHandling,
         remoteConfig: FirebaseRemoteConfig,
     ) {
         when (this) {
@@ -23,7 +25,7 @@ enum class RemoteConfigKeys(val key: String) {
 
             ExternalBridge -> {
                 runCatching {
-                    val list = settingsHandling
+                    val list = newSettingsHandling
                         .customUrls
                         .firstOrNull()
                         .orEmpty()
@@ -32,7 +34,7 @@ enum class RemoteConfigKeys(val key: String) {
 
                     list
                         .filter { it !in json }
-                        .forEach { settingsHandling.addCustomUrl(it) }
+                        .forEach { newSettingsHandling.addCustomUrl(it) }
                 }.onFailure { it.printStackTrace() }
             }
         }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/datastore/SettingsHandling.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/datastore/SettingsHandling.kt
@@ -13,6 +13,7 @@ import androidx.datastore.dataStore
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.protobuf.GeneratedMessageLite
 import com.google.protobuf.InvalidProtocolBufferException
+import com.programmersbox.datastore.NewSettingsHandling
 import com.programmersbox.uiviews.GridChoice
 import com.programmersbox.uiviews.MiddleNavigationAction
 import com.programmersbox.uiviews.NotificationSortBy
@@ -23,9 +24,12 @@ import com.programmersbox.uiviews.middleMultipleActions
 import com.programmersbox.uiviews.settings
 import com.programmersbox.uiviews.utils.PerformanceClass
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.InputStream
@@ -91,7 +95,7 @@ class SettingsHandling(
     private val performanceClass: PerformanceClass,
 ) {
     private val preferences by lazy { context.settings }
-    private val all: Flow<Settings> get() = preferences.data
+    internal val all: Flow<Settings> get() = preferences.data
 
     @Composable
     fun rememberSystemThemeMode() = preferences.rememberPreference(
@@ -283,4 +287,78 @@ class ProtoStoreHandler<T, DS, MessageType, BuilderType>(
             }
         }
     }
+}
+
+fun migrateSettings(
+    settingsHandling: SettingsHandling,
+    newSettingsHandling: NewSettingsHandling,
+) {
+    fun getAction(action: MiddleNavigationAction) = when (action) {
+        MiddleNavigationAction.All -> com.programmersbox.datastore.MiddleNavigationAction.All
+        MiddleNavigationAction.Notifications -> com.programmersbox.datastore.MiddleNavigationAction.Notifications
+        MiddleNavigationAction.Lists -> com.programmersbox.datastore.MiddleNavigationAction.Lists
+        MiddleNavigationAction.Favorites -> com.programmersbox.datastore.MiddleNavigationAction.Favorites
+        MiddleNavigationAction.Search -> com.programmersbox.datastore.MiddleNavigationAction.Search
+        MiddleNavigationAction.Multiple -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
+        MiddleNavigationAction.UNRECOGNIZED -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
+    }
+
+    settingsHandling
+        .all
+        .onEach { old ->
+            println("Migrating old settings")
+            newSettingsHandling.preferences.updateData {
+                it.copy(
+                    themeSetting = when (old.themeSetting) {
+                        SystemThemeMode.FollowSystem -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
+                        SystemThemeMode.Day -> com.programmersbox.datastore.SystemThemeMode.Day
+                        SystemThemeMode.Night -> com.programmersbox.datastore.SystemThemeMode.Night
+                        SystemThemeMode.UNRECOGNIZED -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
+                    },
+                    showListDetail = old.showListDetail,
+                    showDownload = old.showDownload,
+                    batteryPercent = old.batteryPercent,
+                    notifyOnReboot = old.notifyOnReboot,
+                    showBlur = old.showBlur,
+                    historySave = old.historySave,
+                    shareChapter = old.shareChapter,
+                    showAll = old.showAll,
+                    shouldCheckUpdate = old.shouldCheckUpdate,
+                    amoledMode = old.amoledMode,
+                    usePalette = old.usePalette,
+                    showExpressiveness = old.showExpressiveness,
+                    gridChoice = when (old.gridChoice) {
+                        GridChoice.FullAdaptive -> com.programmersbox.datastore.GridChoice.FullAdaptive
+                        GridChoice.Adaptive -> com.programmersbox.datastore.GridChoice.Adaptive
+                        GridChoice.Fixed -> com.programmersbox.datastore.GridChoice.Fixed
+                        GridChoice.UNRECOGNIZED -> com.programmersbox.datastore.GridChoice.FullAdaptive
+                    },
+                    themeColor = when (old.themeColor) {
+                        ThemeColor.Dynamic -> com.programmersbox.datastore.ThemeColor.Dynamic
+                        ThemeColor.Blue -> com.programmersbox.datastore.ThemeColor.Blue
+                        ThemeColor.Red -> com.programmersbox.datastore.ThemeColor.Red
+                        ThemeColor.Green -> com.programmersbox.datastore.ThemeColor.Green
+                        ThemeColor.Yellow -> com.programmersbox.datastore.ThemeColor.Yellow
+                        ThemeColor.Cyan -> com.programmersbox.datastore.ThemeColor.Cyan
+                        ThemeColor.Magenta -> com.programmersbox.datastore.ThemeColor.Magenta
+                        ThemeColor.Custom -> com.programmersbox.datastore.ThemeColor.Custom
+                        ThemeColor.UNRECOGNIZED -> com.programmersbox.datastore.ThemeColor.Dynamic
+                    },
+                    middleNavigationAction = getAction(old.middleNavigationAction),
+                    multipleActions = old.multipleActions?.let {
+                        com.programmersbox.datastore.MiddleMultipleActions(
+                            startAction = getAction(it.startAction),
+                            endAction = getAction(it.endAction),
+                        )
+                    },
+                    notificationSortBy = when (old.notificationSortBy) {
+                        NotificationSortBy.Date -> com.programmersbox.datastore.NotificationSortBy.Date
+                        NotificationSortBy.Grouped -> com.programmersbox.datastore.NotificationSortBy.Grouped
+                        NotificationSortBy.UNRECOGNIZED -> com.programmersbox.datastore.NotificationSortBy.Date
+                    },
+                )
+                    .also { println(it) }
+            }
+        }
+        .launchIn(GlobalScope)
 }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/datastore/SettingsHandling.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/datastore/SettingsHandling.kt
@@ -10,10 +10,13 @@ import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.Serializer
 import androidx.datastore.dataStore
+import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.protobuf.GeneratedMessageLite
 import com.google.protobuf.InvalidProtocolBufferException
+import com.programmersbox.datastore.DataStoreHandling
 import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.otakuDataStore
 import com.programmersbox.uiviews.GridChoice
 import com.programmersbox.uiviews.MiddleNavigationAction
 import com.programmersbox.uiviews.NotificationSortBy
@@ -27,9 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.InputStream
@@ -290,75 +291,91 @@ class ProtoStoreHandler<T, DS, MessageType, BuilderType>(
 }
 
 fun migrateSettings(
+    context: Context,
+    dataStoreHandling: DataStoreHandling,
     settingsHandling: SettingsHandling,
     newSettingsHandling: NewSettingsHandling,
 ) {
-    fun getAction(action: MiddleNavigationAction) = when (action) {
-        MiddleNavigationAction.All -> com.programmersbox.datastore.MiddleNavigationAction.All
-        MiddleNavigationAction.Notifications -> com.programmersbox.datastore.MiddleNavigationAction.Notifications
-        MiddleNavigationAction.Lists -> com.programmersbox.datastore.MiddleNavigationAction.Lists
-        MiddleNavigationAction.Favorites -> com.programmersbox.datastore.MiddleNavigationAction.Favorites
-        MiddleNavigationAction.Search -> com.programmersbox.datastore.MiddleNavigationAction.Search
-        MiddleNavigationAction.Multiple -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
-        MiddleNavigationAction.UNRECOGNIZED -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
-    }
-
-    settingsHandling
-        .all
-        .onEach { old ->
-            println("Migrating old settings")
-            newSettingsHandling.preferences.updateData {
-                it.copy(
-                    themeSetting = when (old.themeSetting) {
-                        SystemThemeMode.FollowSystem -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
-                        SystemThemeMode.Day -> com.programmersbox.datastore.SystemThemeMode.Day
-                        SystemThemeMode.Night -> com.programmersbox.datastore.SystemThemeMode.Night
-                        SystemThemeMode.UNRECOGNIZED -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
-                    },
-                    showListDetail = old.showListDetail,
-                    showDownload = old.showDownload,
-                    batteryPercent = old.batteryPercent,
-                    notifyOnReboot = old.notifyOnReboot,
-                    showBlur = old.showBlur,
-                    historySave = old.historySave,
-                    shareChapter = old.shareChapter,
-                    showAll = old.showAll,
-                    shouldCheckUpdate = old.shouldCheckUpdate,
-                    amoledMode = old.amoledMode,
-                    usePalette = old.usePalette,
-                    showExpressiveness = old.showExpressiveness,
-                    gridChoice = when (old.gridChoice) {
-                        GridChoice.FullAdaptive -> com.programmersbox.datastore.GridChoice.FullAdaptive
-                        GridChoice.Adaptive -> com.programmersbox.datastore.GridChoice.Adaptive
-                        GridChoice.Fixed -> com.programmersbox.datastore.GridChoice.Fixed
-                        GridChoice.UNRECOGNIZED -> com.programmersbox.datastore.GridChoice.FullAdaptive
-                    },
-                    themeColor = when (old.themeColor) {
-                        ThemeColor.Dynamic -> com.programmersbox.datastore.ThemeColor.Dynamic
-                        ThemeColor.Blue -> com.programmersbox.datastore.ThemeColor.Blue
-                        ThemeColor.Red -> com.programmersbox.datastore.ThemeColor.Red
-                        ThemeColor.Green -> com.programmersbox.datastore.ThemeColor.Green
-                        ThemeColor.Yellow -> com.programmersbox.datastore.ThemeColor.Yellow
-                        ThemeColor.Cyan -> com.programmersbox.datastore.ThemeColor.Cyan
-                        ThemeColor.Magenta -> com.programmersbox.datastore.ThemeColor.Magenta
-                        ThemeColor.Custom -> com.programmersbox.datastore.ThemeColor.Custom
-                        ThemeColor.UNRECOGNIZED -> com.programmersbox.datastore.ThemeColor.Dynamic
-                    },
-                    middleNavigationAction = getAction(old.middleNavigationAction),
-                    multipleActions = old.multipleActions?.let {
-                        com.programmersbox.datastore.MiddleMultipleActions(
-                            startAction = getAction(it.startAction),
-                            endAction = getAction(it.endAction),
-                        )
-                    },
-                    notificationSortBy = when (old.notificationSortBy) {
-                        NotificationSortBy.Date -> com.programmersbox.datastore.NotificationSortBy.Date
-                        NotificationSortBy.Grouped -> com.programmersbox.datastore.NotificationSortBy.Grouped
-                        NotificationSortBy.UNRECOGNIZED -> com.programmersbox.datastore.NotificationSortBy.Date
-                    },
-                )
-                    .also { println(it) }
-            }
+    GlobalScope.launch {
+        if (!dataStoreHandling.hasMigrated.get()) {
+            context
+                .dataStore
+                .data
+                .firstOrNull()
+                ?.let { old -> otakuDataStore.edit { new -> new += old } }
+            dataStoreHandling.hasMigrated.set(true)
         }
-        .launchIn(GlobalScope)
+
+        fun getAction(action: MiddleNavigationAction) = when (action) {
+            MiddleNavigationAction.All -> com.programmersbox.datastore.MiddleNavigationAction.All
+            MiddleNavigationAction.Notifications -> com.programmersbox.datastore.MiddleNavigationAction.Notifications
+            MiddleNavigationAction.Lists -> com.programmersbox.datastore.MiddleNavigationAction.Lists
+            MiddleNavigationAction.Favorites -> com.programmersbox.datastore.MiddleNavigationAction.Favorites
+            MiddleNavigationAction.Search -> com.programmersbox.datastore.MiddleNavigationAction.Search
+            MiddleNavigationAction.Multiple -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
+            MiddleNavigationAction.UNRECOGNIZED -> com.programmersbox.datastore.MiddleNavigationAction.Multiple
+        }
+
+        if (!newSettingsHandling.hasMigrated.get()) {
+            settingsHandling
+                .all
+                .firstOrNull()
+                ?.let { old ->
+                    println("Migrating old settings")
+                    newSettingsHandling.preferences.updateData {
+                        it.copy(
+                            themeSetting = when (old.themeSetting) {
+                                SystemThemeMode.FollowSystem -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
+                                SystemThemeMode.Day -> com.programmersbox.datastore.SystemThemeMode.Day
+                                SystemThemeMode.Night -> com.programmersbox.datastore.SystemThemeMode.Night
+                                SystemThemeMode.UNRECOGNIZED -> com.programmersbox.datastore.SystemThemeMode.FollowSystem
+                            },
+                            showListDetail = old.showListDetail,
+                            showDownload = old.showDownload,
+                            batteryPercent = old.batteryPercent,
+                            notifyOnReboot = old.notifyOnReboot,
+                            showBlur = old.showBlur,
+                            historySave = old.historySave,
+                            shareChapter = old.shareChapter,
+                            showAll = old.showAll,
+                            shouldCheckUpdate = old.shouldCheckUpdate,
+                            amoledMode = old.amoledMode,
+                            usePalette = old.usePalette,
+                            showExpressiveness = old.showExpressiveness,
+                            gridChoice = when (old.gridChoice) {
+                                GridChoice.FullAdaptive -> com.programmersbox.datastore.GridChoice.FullAdaptive
+                                GridChoice.Adaptive -> com.programmersbox.datastore.GridChoice.Adaptive
+                                GridChoice.Fixed -> com.programmersbox.datastore.GridChoice.Fixed
+                                GridChoice.UNRECOGNIZED -> com.programmersbox.datastore.GridChoice.FullAdaptive
+                            },
+                            themeColor = when (old.themeColor) {
+                                ThemeColor.Dynamic -> com.programmersbox.datastore.ThemeColor.Dynamic
+                                ThemeColor.Blue -> com.programmersbox.datastore.ThemeColor.Blue
+                                ThemeColor.Red -> com.programmersbox.datastore.ThemeColor.Red
+                                ThemeColor.Green -> com.programmersbox.datastore.ThemeColor.Green
+                                ThemeColor.Yellow -> com.programmersbox.datastore.ThemeColor.Yellow
+                                ThemeColor.Cyan -> com.programmersbox.datastore.ThemeColor.Cyan
+                                ThemeColor.Magenta -> com.programmersbox.datastore.ThemeColor.Magenta
+                                ThemeColor.Custom -> com.programmersbox.datastore.ThemeColor.Custom
+                                ThemeColor.UNRECOGNIZED -> com.programmersbox.datastore.ThemeColor.Dynamic
+                            },
+                            middleNavigationAction = getAction(old.middleNavigationAction),
+                            multipleActions = old.multipleActions?.let {
+                                com.programmersbox.datastore.MiddleMultipleActions(
+                                    startAction = getAction(it.startAction),
+                                    endAction = getAction(it.endAction),
+                                )
+                            },
+                            notificationSortBy = when (old.notificationSortBy) {
+                                NotificationSortBy.Date -> com.programmersbox.datastore.NotificationSortBy.Date
+                                NotificationSortBy.Grouped -> com.programmersbox.datastore.NotificationSortBy.Grouped
+                                NotificationSortBy.UNRECOGNIZED -> com.programmersbox.datastore.NotificationSortBy.Date
+                            },
+                            hasMigrated = true,
+                        )
+                            .also { println(it) }
+                    }
+                }
+        }
+    }
 }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/components/MultipleActions.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/components/MultipleActions.kt
@@ -32,8 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
-import com.programmersbox.uiviews.MiddleMultipleActions
-import com.programmersbox.uiviews.MiddleNavigationAction
 import com.programmersbox.uiviews.utils.customsettings.ScreenBottomItem
 import com.programmersbox.uiviews.utils.customsettings.item
 import kotlinx.coroutines.delay
@@ -71,14 +69,14 @@ class MultipleBarState(
 @Composable
 fun BoxScope.MultipleActions(
     state: MultipleBarState,
-    middleNavItem: MiddleNavigationAction,
-    multipleActions: MiddleMultipleActions,
+    middleNavItem: com.programmersbox.datastore.MiddleNavigationAction,
+    multipleActions: com.programmersbox.datastore.MiddleMultipleActions,
     currentDestination: NavDestination?,
     navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
-    if (middleNavItem == MiddleNavigationAction.Multiple) {
+    if (middleNavItem == com.programmersbox.datastore.MiddleNavigationAction.Multiple) {
         MultipleActions(
             state = state,
             leadingContent = {

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/components/SelectableMiniPalette.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/components/SelectableMiniPalette.kt
@@ -34,7 +34,20 @@ import androidx.compose.ui.unit.dp
 import com.materialkolor.ktx.from
 import com.materialkolor.palettes.TonalPalette
 import com.materialkolor.rememberDynamicColorScheme
-import com.programmersbox.uiviews.ThemeColor
+import com.programmersbox.datastore.ThemeColor
+
+val com.programmersbox.uiviews.ThemeColor.seedColor
+    get() = when (this) {
+        com.programmersbox.uiviews.ThemeColor.Dynamic -> Color.Transparent
+        com.programmersbox.uiviews.ThemeColor.Blue -> Color.Blue
+        com.programmersbox.uiviews.ThemeColor.Red -> Color.Red
+        com.programmersbox.uiviews.ThemeColor.Green -> Color.Green
+        com.programmersbox.uiviews.ThemeColor.Yellow -> Color.Yellow
+        com.programmersbox.uiviews.ThemeColor.Cyan -> Color.Cyan
+        com.programmersbox.uiviews.ThemeColor.Magenta -> Color.Magenta
+        com.programmersbox.uiviews.ThemeColor.Custom -> Color.Transparent
+        else -> Color.Transparent
+    }
 
 val ThemeColor.seedColor
     get() = when (this) {

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/notifications/NotificationFragment.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/notifications/NotificationFragment.kt
@@ -97,6 +97,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.google.android.material.datepicker.DateValidatorPointForward
+import com.programmersbox.datastore.NotificationSortBy
 import com.programmersbox.extensionloader.SourceRepository
 import com.programmersbox.favoritesdatabase.ItemDao
 import com.programmersbox.favoritesdatabase.NotificationItem
@@ -106,7 +107,6 @@ import com.programmersbox.gsonutils.toJson
 import com.programmersbox.models.ApiService
 import com.programmersbox.sharedutils.AppLogo
 import com.programmersbox.uiviews.GenericInfo
-import com.programmersbox.uiviews.NotificationSortBy
 import com.programmersbox.uiviews.R
 import com.programmersbox.uiviews.checkers.NotifySingleWorker
 import com.programmersbox.uiviews.checkers.SavedNotifications
@@ -333,8 +333,6 @@ fun NotificationsScreen(
                         }
                     )
                 }
-
-                NotificationSortBy.UNRECOGNIZED -> {}
             }
         }
 

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/notifications/NotificationScreenViewModel.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/notifications/NotificationScreenViewModel.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.NotificationSortBy
 import com.programmersbox.extensionloader.SourceRepository
 import com.programmersbox.favoritesdatabase.ItemDao
 import com.programmersbox.favoritesdatabase.NotificationItem
-import com.programmersbox.uiviews.NotificationSortBy
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.repository.NotificationRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
@@ -23,7 +23,7 @@ import kotlinx.coroutines.withContext
 
 class NotificationScreenViewModel(
     private val db: ItemDao,
-    settingsHandling: SettingsHandling,
+    settingsHandling: NewSettingsHandling,
     sourceRepository: SourceRepository,
     private val notificationRepository: NotificationRepository,
 ) : ViewModel() {
@@ -98,7 +98,6 @@ class NotificationScreenViewModel(
                 when (sortedBy) {
                     NotificationSortBy.Date -> NotificationSortBy.Grouped
                     NotificationSortBy.Grouped -> NotificationSortBy.Date
-                    NotificationSortBy.UNRECOGNIZED -> NotificationSortBy.Date
                 }
             )
         }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/onboarding/OnboardingContent.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/onboarding/OnboardingContent.kt
@@ -59,13 +59,13 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.materialkolor.rememberDynamicColorScheme
 import com.programmersbox.datastore.DataStoreHandling
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.SystemThemeMode
+import com.programmersbox.datastore.ThemeColor
 import com.programmersbox.datastore.asState
 import com.programmersbox.sharedutils.AppLogo
 import com.programmersbox.uiviews.BuildConfig
 import com.programmersbox.uiviews.R
-import com.programmersbox.uiviews.SystemThemeMode
-import com.programmersbox.uiviews.ThemeColor
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.presentation.Screen
 import com.programmersbox.uiviews.presentation.components.ListSetting
 import com.programmersbox.uiviews.presentation.components.PreferenceSetting
@@ -90,7 +90,7 @@ import org.koin.compose.koinInject
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
 internal fun ThemeContent(
-    handling: SettingsHandling = koinInject(),
+    handling: NewSettingsHandling = koinInject(),
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -153,7 +153,7 @@ internal fun ThemeContent(
             modifier = Modifier.fillMaxWidth(),
         ) {
             ThemeColor.entries
-                .filter { it != ThemeColor.Custom && it != ThemeColor.UNRECOGNIZED }
+                .filter { it != ThemeColor.Custom }
                 .forEach {
                     ThemeItem(
                         themeColor = it,
@@ -355,7 +355,7 @@ internal fun WelcomeContent(
 
 @Composable
 internal fun GeneralContent() {
-    val handling = koinInject<SettingsHandling>()
+    val handling = koinInject<NewSettingsHandling>()
     val dataStoreHandling = koinInject<DataStoreHandling>()
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/GeneralSettings.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/GeneralSettings.kt
@@ -53,15 +53,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.materialkolor.PaletteStyle
 import com.materialkolor.rememberDynamicColorScheme
+import com.programmersbox.datastore.GridChoice
+import com.programmersbox.datastore.MiddleNavigationAction
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.SystemThemeMode
+import com.programmersbox.datastore.ThemeColor
 import com.programmersbox.datastore.rememberFloatingNavigation
 import com.programmersbox.datastore.rememberHistorySave
-import com.programmersbox.uiviews.GridChoice
-import com.programmersbox.uiviews.MiddleNavigationAction
 import com.programmersbox.uiviews.R
-import com.programmersbox.uiviews.SystemThemeMode
-import com.programmersbox.uiviews.ThemeColor
-import com.programmersbox.uiviews.copy
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.datastore.rememberSwatchStyle
 import com.programmersbox.uiviews.datastore.rememberSwatchType
 import com.programmersbox.uiviews.presentation.components.ListSetting
@@ -74,7 +73,6 @@ import com.programmersbox.uiviews.presentation.components.ThemeItem
 import com.programmersbox.uiviews.presentation.components.seedColor
 import com.programmersbox.uiviews.presentation.details.PaletteSwatchType
 import com.programmersbox.uiviews.utils.LightAndDarkPreviews
-import com.programmersbox.uiviews.utils.LocalSettingsHandling
 import com.programmersbox.uiviews.utils.LocalWindowSizeClass
 import com.programmersbox.uiviews.utils.PerformanceClass
 import com.programmersbox.uiviews.utils.PreviewTheme
@@ -94,7 +92,7 @@ fun GeneralSettings(
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         val performanceClass = koinInject<PerformanceClass>()
-        val handling = LocalSettingsHandling.current
+        val handling: NewSettingsHandling = koinInject()
 
         var isAmoledMode by handling.rememberIsAmoledMode()
 
@@ -136,7 +134,7 @@ fun GeneralSettings(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
-fun NavigationBarSettings(handling: SettingsHandling) {
+fun NavigationBarSettings(handling: NewSettingsHandling) {
     var floatingNavigation by rememberFloatingNavigation()
 
     SwitchSetting(
@@ -166,7 +164,7 @@ fun NavigationBarSettings(handling: SettingsHandling) {
             summaryValue = { Text(middleNavigationAction.visibleName) },
             confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(R.string.cancel)) } },
             value = middleNavigationAction,
-            options = MiddleNavigationAction.entries.filter { it != MiddleNavigationAction.UNRECOGNIZED },
+            options = MiddleNavigationAction.entries,
             updateValue = { it, d ->
                 d.value = false
                 middleNavigationAction = it
@@ -185,14 +183,14 @@ fun NavigationBarSettings(handling: SettingsHandling) {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun MultipleActionsSetting(
-    handling: SettingsHandling,
+    handling: NewSettingsHandling,
     middleNavigationAction: MiddleNavigationAction,
 ) {
     var multipleActions by handling.rememberMiddleMultipleActions()
 
-    val multipleActionOptions = MiddleNavigationAction.entries
+    val multipleActionOptions = MiddleNavigationAction
+        .entries
         .filter { it != MiddleNavigationAction.Multiple }
-        .filter { it != MiddleNavigationAction.UNRECOGNIZED }
 
     ShowWhen(middleNavigationAction == MiddleNavigationAction.Multiple) {
         PreferenceSetting(
@@ -212,9 +210,11 @@ private fun MultipleActionsSetting(
                             ) {
                                 multipleActionOptions.forEach {
                                     DropdownMenuItem(
-                                        text = { Text(it.visibleName) },
+                                        text = { Text(it.name) },
                                         onClick = {
-                                            multipleActions = multipleActions.copy { startAction = it }
+                                            multipleActions = multipleActions?.copy(
+                                                startAction = it,
+                                            )
                                             showMenu = false
                                         }
                                     )
@@ -226,8 +226,8 @@ private fun MultipleActionsSetting(
                             ) {
                                 Icon(
                                     multipleActions
-                                        .startAction
-                                        .item
+                                        ?.startAction
+                                        ?.item
                                         ?.icon
                                         ?.invoke(true)
                                         ?: Icons.Default.Add,
@@ -245,7 +245,7 @@ private fun MultipleActionsSetting(
                                     DropdownMenuItem(
                                         text = { Text(it.visibleName) },
                                         onClick = {
-                                            multipleActions = multipleActions.copy { endAction = it }
+                                            multipleActions = multipleActions?.copy(endAction = it)
                                             showMenu = false
                                         }
                                     )
@@ -256,8 +256,8 @@ private fun MultipleActionsSetting(
                             ) {
                                 Icon(
                                     multipleActions
-                                        .endAction
-                                        .item
+                                        ?.endAction
+                                        ?.item
                                         ?.icon
                                         ?.invoke(true)
                                         ?: Icons.Default.Add,
@@ -286,7 +286,7 @@ private fun MultipleActionsSetting(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
 @Composable
 private fun ThemeSetting(
-    handling: SettingsHandling,
+    handling: NewSettingsHandling,
     isAmoledMode: Boolean,
 ) {
     var themeSetting by handling.rememberSystemThemeMode()
@@ -331,7 +331,7 @@ private fun ThemeSetting(
         ) {
             ThemeColor.entries
                 //TODO: For later
-                .filter { it != ThemeColor.Custom && it != ThemeColor.UNRECOGNIZED }
+                .filter { it != ThemeColor.Custom }
                 .forEach {
                     ThemeItem(
                         themeColor = it,
@@ -370,7 +370,7 @@ private fun AmoledModeSetting(
 }
 
 @Composable
-private fun ExpressivenessSetting(handling: SettingsHandling) {
+private fun ExpressivenessSetting(handling: NewSettingsHandling) {
     var showExpressiveness by handling.rememberShowExpressiveness()
     SwitchSetting(
         settingTitle = { Text("Show Expressiveness") },
@@ -382,7 +382,7 @@ private fun ExpressivenessSetting(handling: SettingsHandling) {
 }
 
 @Composable
-fun BlurSetting(handling: SettingsHandling) {
+fun BlurSetting(handling: NewSettingsHandling) {
     var showBlur by handling.rememberShowBlur()
 
     SwitchSetting(
@@ -402,7 +402,7 @@ fun BlurSetting(handling: SettingsHandling) {
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
-private fun PaletteSetting(handling: SettingsHandling) {
+private fun PaletteSetting(handling: NewSettingsHandling) {
     var usePalette by handling.rememberUsePalette()
 
     SwitchSetting(
@@ -452,7 +452,7 @@ private fun PaletteSetting(handling: SettingsHandling) {
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
-private fun GridTypeSettings(handling: SettingsHandling) {
+private fun GridTypeSettings(handling: NewSettingsHandling) {
     var gridChoice by handling.rememberGridChoice()
 
     ListSetting(
@@ -485,7 +485,7 @@ private fun GridTypeSettings(handling: SettingsHandling) {
 }
 
 @Composable
-fun ShareChapterSettings(handling: SettingsHandling) {
+fun ShareChapterSettings(handling: NewSettingsHandling) {
     var shareChapter by handling.rememberShareChapter()
 
     SwitchSetting(
@@ -497,7 +497,7 @@ fun ShareChapterSettings(handling: SettingsHandling) {
 }
 
 @Composable
-private fun DetailPaneSettings(handling: SettingsHandling) {
+private fun DetailPaneSettings(handling: NewSettingsHandling) {
     var showListDetail by handling.rememberShowListDetail()
 
     SwitchSetting(
@@ -515,7 +515,7 @@ private fun DetailPaneSettings(handling: SettingsHandling) {
 }
 
 @Composable
-fun ShowDownloadSettings(handling: SettingsHandling) {
+fun ShowDownloadSettings(handling: NewSettingsHandling) {
     var showDownload by handling.rememberShowDownload()
 
     SwitchSetting(
@@ -527,7 +527,7 @@ fun ShowDownloadSettings(handling: SettingsHandling) {
 }
 
 @Composable
-private fun HistorySettings(handling: SettingsHandling) {
+private fun HistorySettings(handling: NewSettingsHandling) {
     var sliderValue by rememberHistorySave()
 
     SliderSetting(

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/PlaySettings.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/PlaySettings.kt
@@ -12,12 +12,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
+import com.programmersbox.datastore.NewSettingsHandling
 import com.programmersbox.uiviews.R
 import com.programmersbox.uiviews.presentation.components.SliderSetting
 import com.programmersbox.uiviews.utils.LightAndDarkPreviews
-import com.programmersbox.uiviews.utils.LocalSettingsHandling
 import com.programmersbox.uiviews.utils.PreviewTheme
 import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,7 +27,7 @@ fun PlaySettings(
 ) {
     SettingsScaffold(stringResource(R.string.playSettings)) {
         val scope = rememberCoroutineScope()
-        val settingsHandling = LocalSettingsHandling.current
+        val settingsHandling: NewSettingsHandling = koinInject()
         val batteryPercent = settingsHandling.batteryPercent
         val slider by batteryPercent.rememberPreference()
         var sliderValue by remember(slider) { mutableFloatStateOf(slider.toFloat()) }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/viewmodels/NotificationViewModel.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/viewmodels/NotificationViewModel.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.programmersbox.datastore.DataStoreHandling
+import com.programmersbox.datastore.NewSettingsHandling
 import com.programmersbox.favoritesdatabase.ItemDao
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.utils.dispatchIo
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -21,7 +21,7 @@ import java.text.SimpleDateFormat
 class NotificationViewModel(
     dao: ItemDao,
     private val dataStoreHandling: DataStoreHandling,
-    settingsHandling: SettingsHandling,
+    settingsHandling: NewSettingsHandling,
 ) : ViewModel() {
 
     var savedNotifications by mutableIntStateOf(0)

--- a/UIViews/src/main/java/com/programmersbox/uiviews/theme/OtakuMaterialTheme.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/theme/OtakuMaterialTheme.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.platform.UriHandler
 import androidx.navigation.NavHostController
 import com.materialkolor.ktx.animateColorScheme
 import com.materialkolor.rememberDynamicColorScheme
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.SystemThemeMode
+import com.programmersbox.datastore.ThemeColor
 import com.programmersbox.extensionloader.SourceRepository
 import com.programmersbox.favoritesdatabase.BlurHashDao
 import com.programmersbox.favoritesdatabase.BlurHashDatabase
@@ -34,9 +37,6 @@ import com.programmersbox.favoritesdatabase.ListDao
 import com.programmersbox.favoritesdatabase.ListDatabase
 import com.programmersbox.uiviews.GenericInfo
 import com.programmersbox.uiviews.R
-import com.programmersbox.uiviews.SystemThemeMode
-import com.programmersbox.uiviews.ThemeColor
-import com.programmersbox.uiviews.datastore.SettingsHandling
 import com.programmersbox.uiviews.datastore.rememberSwatchStyle
 import com.programmersbox.uiviews.presentation.components.seedColor
 import com.programmersbox.uiviews.repository.CurrentSourceRepository
@@ -65,7 +65,7 @@ fun OtakuMaterialTheme(
     navController: NavHostController,
     genericInfo: GenericInfo,
     isAmoledMode: Boolean = false,
-    settingsHandling: SettingsHandling,
+    settingsHandling: NewSettingsHandling,
     content: @Composable () -> Unit,
 ) {
     val defaultUriHandler = LocalUriHandler.current

--- a/UIViews/src/main/java/com/programmersbox/uiviews/utils/customsettings/MiddleNavAction.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/utils/customsettings/MiddleNavAction.kt
@@ -27,7 +27,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-import com.programmersbox.uiviews.MiddleNavigationAction
+import com.programmersbox.datastore.MiddleNavigationAction
 import com.programmersbox.uiviews.R
 import com.programmersbox.uiviews.presentation.Screen
 
@@ -37,7 +37,7 @@ data class MiddleNavigationItem(
     val label: Int,
 )
 
-val MiddleNavigationAction.visibleName get() = if (this == MiddleNavigationAction.UNRECOGNIZED) "None" else name
+val MiddleNavigationAction.visibleName get() = name
 
 val MiddleNavigationAction.item: MiddleNavigationItem?
     get() = when (this) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ plugins {
     alias(libs.plugins.google.firebase.performance) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.composeMultiplatform) apply false
+    id("com.squareup.wire") version "5.3.1" apply false
 }
 
 projectInfo {

--- a/datastore/build.gradle.kts
+++ b/datastore/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     //`otaku-protobuf`
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.compose.compiler)
+    id("com.squareup.wire")
 }
 
 otakuDependencies {
@@ -24,7 +25,14 @@ kotlin {
             //implementation(libs.composeRuntimeLivedata)
             implementation(compose.runtime)
             implementation(libs.multiplatform.lifecycle.runtime.compose)
-
+            implementation("androidx.datastore:datastore-core-okio:${libs.versions.datastore.get()}")
         }
+    }
+}
+
+wire {
+    kotlin {}
+    sourcePath {
+        srcDir("src/commonMain/proto")
     }
 }

--- a/datastore/src/androidMain/kotlin/com/programmersbox/datastore/Platform.android.kt
+++ b/datastore/src/androidMain/kotlin/com/programmersbox/datastore/Platform.android.kt
@@ -1,3 +1,20 @@
 package com.programmersbox.datastore
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
 actual fun platform() = "Android"
+
+actual fun getDataStore(
+    producePath: () -> Path,
+): DataStore<Settings> {
+    //val producePath = { content.filesDir.resolve("Settings").absolutePath.toPath() }
+
+    return createDataStore(fileSystem = FileSystem.SYSTEM, producePath = producePath)
+}
+
+fun createProtobuf(context: Context) =
+    getDataStore { context.filesDir.resolve(DATA_STORE_FILE_NAME).absolutePath.toPath() }

--- a/datastore/src/commonMain/kotlin/com/programmersbox/datastore/DataStoreHandling.kt
+++ b/datastore/src/commonMain/kotlin/com/programmersbox/datastore/DataStoreHandling.kt
@@ -54,4 +54,9 @@ class DataStoreHandling {
         key = booleanPreferencesKey("hasGoneThroughOnboarding"),
         defaultValue = false
     )
+
+    val hasMigrated = DataStoreHandler(
+        key = booleanPreferencesKey("hasMigrated"),
+        defaultValue = false
+    )
 }

--- a/datastore/src/commonMain/kotlin/com/programmersbox/datastore/Platform.kt
+++ b/datastore/src/commonMain/kotlin/com/programmersbox/datastore/Platform.kt
@@ -1,3 +1,26 @@
 package com.programmersbox.datastore
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.okio.OkioStorage
+import okio.FileSystem
+import okio.Path
+
 expect fun platform(): String
+
+internal const val DATA_STORE_FILE_NAME = "Settings.preferences_pb"
+
+expect fun getDataStore(
+    producePath: () -> Path,
+): DataStore<Settings>
+
+fun createDataStore(
+    fileSystem: FileSystem,
+    producePath: () -> Path,
+): DataStore<Settings> = DataStoreFactory.create(
+    storage = OkioStorage(
+        fileSystem = fileSystem,
+        producePath = producePath,
+        serializer = SettingsSerializer,
+    ),
+)

--- a/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
+++ b/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
@@ -1,0 +1,286 @@
+package com.programmersbox.datastore
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.core.okio.OkioSerializer
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okio.BufferedSink
+import okio.BufferedSource
+
+interface GenericSerializer<MessageType> : OkioSerializer<MessageType> {
+    /*where MessageType : GeneratedMessageLite<MessageType, BuilderType>,
+          BuilderType : GeneratedMessageLite.Builder<MessageType, BuilderType> {*/
+
+    /**
+     * Call MessageType::parseFrom here!
+     */
+    val parseFrom: (input: BufferedSource) -> MessageType
+
+    override suspend fun readFrom(source: BufferedSource): MessageType {
+        return withContext(Dispatchers.IO) {
+            try {
+                return@withContext parseFrom(source)
+            } catch (exception: IOException) {
+                throw Exception(exception.message ?: "Serialization Exception")
+            }
+        }
+    }
+
+    override suspend fun writeTo(t: MessageType, sink: BufferedSink) {
+        withContext(Dispatchers.IO) { sink.write(encode(t)) }
+    }
+
+    fun encode(t: MessageType): ByteArray
+
+    /*override suspend fun readFrom(input: InputStream): MessageType =
+        withContext(Dispatchers.IO) {
+            try {
+                parseFrom(input)
+            } catch (exception: InvalidProtocolBufferException) {
+                throw CorruptionException("Cannot read proto.", exception)
+            }
+        }*/
+
+    /*override suspend fun writeTo(t: MessageType, output: OutputStream) =
+        withContext(Dispatchers.IO) { t.writeTo(output) }*/
+}
+
+/*val settings: DataStore<Settings> by dataStore(
+    fileName = "Settings",
+    serializer = SettingsSerializer
+)*/
+
+object SettingsSerializer : GenericSerializer<Settings> {
+    override val defaultValue: Settings
+        get() = Settings(
+            batteryPercent = 20,
+            historySave = 50,
+            shareChapter = true,
+            showAll = true,
+            shouldCheckUpdate = true,
+            themeSetting = SystemThemeMode.FollowSystem,
+            showListDetail = true,
+            showDownload = true,
+            amoledMode = false,
+            usePalette = true,
+            showBlur = true,//PerformanceClass.canBlur(),
+            showExpressiveness = true,
+            notifyOnReboot = true,
+            multipleActions = MiddleMultipleActions(
+                startAction = MiddleNavigationAction.All,
+                endAction = MiddleNavigationAction.Notifications,
+            ),
+        )
+
+    override val parseFrom: (input: BufferedSource) -> Settings get() = Settings.ADAPTER::decode
+
+    override fun encode(t: Settings): ByteArray = t.encode()
+}
+
+class NewSettingsHandling(
+    val preferences: DataStore<Settings>,
+    //private val performanceClass: PerformanceClass,
+) {
+    private val all: Flow<Settings> get() = preferences.data
+
+    @Composable
+    fun rememberSystemThemeMode() = preferences.rememberPreference(
+        key = { it.themeSetting },
+        update = { copy(themeSetting = it) },
+        defaultValue = SystemThemeMode.FollowSystem
+    )
+
+    val batteryPercent = ProtoStoreHandler(
+        preferences = preferences,
+        key = { it.batteryPercent },
+        update = { copy(batteryPercent = it) },
+        defaultValue = 20
+    )
+
+    val notifyOnReboot = ProtoStoreHandler(
+        preferences = preferences,
+        key = { it.notifyOnReboot },
+        update = { copy(notifyOnReboot = it) },
+        defaultValue = true
+    )
+
+    @Composable
+    fun rememberShareChapter() = preferences.rememberPreference(
+        key = { it.shareChapter },
+        update = { copy(shareChapter = it) },
+        defaultValue = true
+    )
+
+    @Composable
+    fun rememberShowAll() = preferences.rememberPreference(
+        key = { it.showAll },
+        update = { copy(showAll = it) },
+        defaultValue = false
+    )
+
+    val notificationSortBy = ProtoStoreHandler(
+        preferences = preferences,
+        key = { it.notificationSortBy },
+        update = { copy(notificationSortBy = it) },
+        defaultValue = NotificationSortBy.Date
+    )
+
+    @Composable
+    fun rememberShowListDetail() = preferences.rememberPreference(
+        key = { it.showListDetail },
+        update = { copy(showListDetail = it) },
+        defaultValue = true
+    )
+
+    val customUrls = all.map { it.customUrls }
+
+    suspend fun addCustomUrl(url: String) = preferences.updateData {
+        it.copy(customUrls = it.customUrls + url)
+    }
+
+    suspend fun removeCustomUrl(url: String) = preferences.updateData {
+        val l = it.customUrls.toMutableList()
+        l.remove(url)
+        it.copy(customUrls = l)
+    }
+
+    @Composable
+    fun rememberShowDownload() = preferences.rememberPreference(
+        key = { it.showDownload },
+        update = { copy(showDownload = it) },
+        defaultValue = false
+    )
+
+    @Composable
+    fun rememberIsAmoledMode() = preferences.rememberPreference(
+        key = { it.amoledMode },
+        update = { copy(amoledMode = it) },
+        defaultValue = true
+    )
+
+    @Composable
+    fun rememberUsePalette() = preferences.rememberPreference(
+        key = { it.usePalette },
+        update = { copy(usePalette = it) },
+        defaultValue = true
+    )
+
+    @Composable
+    fun rememberShowBlur() = preferences.rememberPreference(
+        key = { it.showBlur },
+        update = { copy(showBlur = it) },
+        defaultValue = true//performanceClass.canBlur
+    )
+
+    @Composable
+    fun rememberGridChoice() = preferences.rememberPreference(
+        key = { it.gridChoice },
+        update = { copy(gridChoice = it) },
+        defaultValue = GridChoice.FullAdaptive
+    )
+
+    @Composable
+    fun rememberThemeColor() = preferences.rememberPreference(
+        key = { it.themeColor },
+        update = { copy(themeColor = it) },
+        defaultValue = ThemeColor.Dynamic
+    )
+
+    @Composable
+    fun rememberShowExpressiveness() = preferences.rememberPreference(
+        key = { it.showExpressiveness },
+        update = { copy(showExpressiveness = it) },
+        defaultValue = true
+    )
+
+    @Composable
+    fun rememberMiddleNavigationAction() = preferences.rememberPreference(
+        key = { it.middleNavigationAction },
+        update = { copy(middleNavigationAction = it) },
+        defaultValue = MiddleNavigationAction.All,
+    )
+
+    @Composable
+    fun rememberMiddleMultipleActions() = preferences.rememberPreference(
+        key = { it.multipleActions },
+        update = { copy(multipleActions = it) },
+        defaultValue = MiddleMultipleActions(
+            startAction = MiddleNavigationAction.All,
+            endAction = MiddleNavigationAction.Notifications
+        )
+    )
+}
+
+@Composable
+fun <T, DS, MessageType> DS.rememberPreference(
+    key: (MessageType) -> T,
+    update: MessageType.(T) -> MessageType,
+    defaultValue: T,
+): MutableState<T> where DS : DataStore<MessageType> {
+    val coroutineScope = rememberCoroutineScope()
+    val state by remember { data.map(key) }.collectAsStateWithLifecycle(initialValue = defaultValue)
+
+    return remember(state) {
+        object : MutableState<T> {
+            override var value: T
+                get() = state
+                set(value) {
+                    coroutineScope.launch {
+                        updateData { it.update(value) }
+                    }
+                }
+
+            override fun component1() = value
+            override fun component2(): (T) -> Unit = { value = it }
+        }
+    }
+}
+
+class ProtoStoreHandler<T, DS, MessageType>(
+    private val preferences: DS,
+    private val key: (MessageType) -> T,
+    private val update: MessageType.(T) -> MessageType,
+    private val defaultValue: T,
+) where DS : DataStore<MessageType> {
+
+    fun asFlow() = preferences.data.map { key(it) }
+
+    suspend fun get() = asFlow().firstOrNull() ?: defaultValue
+
+    suspend fun set(value: T) {
+        preferences.updateData { it.update(value) }
+    }
+
+    @Composable
+    fun rememberPreference(): MutableState<T> {
+        val coroutineScope = rememberCoroutineScope()
+        val state by remember { preferences.data.map(key) }.collectAsStateWithLifecycle(initialValue = defaultValue)
+
+        return remember(state) {
+            object : MutableState<T> {
+                override var value: T
+                    get() = state
+                    set(value) {
+                        coroutineScope.launch {
+                            this@ProtoStoreHandler.set(value)
+                        }
+                    }
+
+                override fun component1() = value
+                override fun component2(): (T) -> Unit = { value = it }
+            }
+        }
+    }
+}

--- a/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
+++ b/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
@@ -78,6 +78,7 @@ object SettingsSerializer : GenericSerializer<Settings> {
             showBlur = true,//PerformanceClass.canBlur(),
             showExpressiveness = true,
             notifyOnReboot = true,
+            hasMigrated = false,
             multipleActions = MiddleMultipleActions(
                 startAction = MiddleNavigationAction.All,
                 endAction = MiddleNavigationAction.Notifications,
@@ -220,6 +221,13 @@ class NewSettingsHandling(
             startAction = MiddleNavigationAction.All,
             endAction = MiddleNavigationAction.Notifications
         )
+    )
+
+    val hasMigrated = ProtoStoreHandler(
+        preferences = preferences,
+        key = { it.hasMigrated },
+        update = { copy(hasMigrated = it) },
+        defaultValue = false
     )
 }
 

--- a/datastore/src/commonMain/proto/settings.proto
+++ b/datastore/src/commonMain/proto/settings.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package com.programmersbox.datastore;
+
+message Settings {
+  SystemThemeMode themeSetting = 1;
+  bool shouldCheckUpdate = 2;
+  int32 batteryPercent = 3;
+  bool shareChapter = 4;
+  bool showAll = 5;
+  int32 historySave = 6;
+  NotificationSortBy notificationSortBy = 7;
+  bool showListDetail = 8;
+  bool showDownload = 9;
+  repeated string customUrls = 10;
+  bool amoledMode = 11;
+  bool usePalette = 12;
+  bool showBlur = 13;
+  GridChoice gridChoice = 15;
+  ThemeColor themeColor = 16;
+  MiddleNavigationAction middleNavigationAction = 17;
+  MiddleMultipleActions multipleActions = 18;
+  bool showExpressiveness = 19;
+  bool notifyOnReboot = 20;
+}
+
+enum SystemThemeMode {
+  FollowSystem = 0;
+  Day = 1;
+  Night = 2;
+}
+
+enum ThemeColor {
+  Dynamic = 0;
+  Blue = 1;
+  Red = 2;
+  Green = 3;
+  Yellow = 4;
+  Cyan = 6;
+  Magenta = 7;
+  Custom = 8;
+}
+
+enum NotificationSortBy {
+  Date = 0;
+  Grouped = 1;
+}
+
+enum GridChoice {
+  FullAdaptive = 0;
+  Adaptive = 1;
+  Fixed = 2;
+}
+
+enum MiddleNavigationAction {
+  All = 0;
+  Notifications = 1;
+  Lists = 2;
+  Favorites = 3;
+  Search = 4;
+  Multiple = 5;
+}
+
+message MiddleMultipleActions {
+  MiddleNavigationAction startAction = 1;
+  MiddleNavigationAction endAction = 2;
+}

--- a/datastore/src/commonMain/proto/settings.proto
+++ b/datastore/src/commonMain/proto/settings.proto
@@ -22,6 +22,7 @@ message Settings {
   MiddleMultipleActions multipleActions = 18;
   bool showExpressiveness = 19;
   bool notifyOnReboot = 20;
+  bool hasMigrated = 21;
 }
 
 enum SystemThemeMode {

--- a/datastore/src/iosMain/kotlin/com/programmersbox/datastore/Platform.ios.kt
+++ b/datastore/src/iosMain/kotlin/com/programmersbox/datastore/Platform.ios.kt
@@ -1,3 +1,31 @@
 package com.programmersbox.datastore
 
+import androidx.datastore.core.DataStore
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
 actual fun platform() = "iOS"
+
+actual fun getDataStore(
+    producePath: () -> Path,
+): DataStore<Settings> {
+    @OptIn(ExperimentalForeignApi::class)
+    val producePath = {
+        val documentDirectory: NSURL? = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )
+        requireNotNull(documentDirectory).path + "/Settings"
+    }
+
+    return createDataStore(fileSystem = FileSystem.SYSTEM, producePath = { producePath().toPath() })
+}

--- a/datastore/src/jvmMain/kotlin/com/programmersbox/datastore/Platform.jvm.kt
+++ b/datastore/src/jvmMain/kotlin/com/programmersbox/datastore/Platform.jvm.kt
@@ -1,3 +1,14 @@
 package com.programmersbox.datastore
 
+import androidx.datastore.core.DataStore
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
 actual fun platform() = "Desktop"
+
+actual fun getDataStore(
+    producePath: () -> Path,
+): DataStore<Settings> {
+    return createDataStore(fileSystem = FileSystem.SYSTEM, producePath = { DATA_STORE_FILE_NAME.toPath() })
+}


### PR DESCRIPTION
This commit introduces a new multiplatform settings system using `DataStore` and migrates existing settings to the new format.

-   **Multiplatform Settings:**
    -   Added a new `Settings` proto file to define the structure of the settings data.
    -   Implemented a new `NewSettingsHandling` class to manage the new settings using `DataStore`.
    -   Added platform-specific implementations for Android, JVM, and iOS to handle data storage.
    -   Added `getDataStore` function to get a `DataStore` instance.
    -   Added a `SettingsSerializer` to handle the serialization and deserialization of the settings data.
    -   Added `createDataStore` function to create a data store instance.
-   - Updated `SettingsHandling` to use `Okio`
+    - Added `createProtobuf` to make getting the data store easier for android.
 -   **Settings Migration:**
     -   Added a migration process to transfer existing settings from the old `SettingsHandling` to the new `NewSettingsHandling`.
-    - Added `migrateSettings` function to migrate old settings.
-    - Added `dataStore.data.onEach` to migrate old settings to new settings.
     - Removed the `UNRECOGNIZED` enum from `GridChoice`, `ThemeColor`, `SystemThemeMode`, `MiddleNavigationAction`, and `NotificationSortBy`
-    - Added `dataStore.data.onEach` to migrate old settings to new settings.
+- Added `migrateSettings` function to migrate old settings.
+- Added `dataStore.data.onEach` to migrate old settings to new settings.
 - **Proto:**
     - Added a `settings.proto` file to define the structure of the `Settings` message.
-    - Added `SettingsSerializer` to read and write to the `proto` file.
+    - Added `SettingsSerializer` to read and write from the `proto` file.
+    - Updated the build.gradle to use wire.
     - Added `GenericSerializer` to handle serialization of `proto` files.
+    - Changed `MiddleNavigationAction.UNRECOGNIZED` to just `MiddleNavigationAction.Multiple`
+    - Changed `MiddleMultipleActions` to use `MiddleNavigationAction`
+    - Updated `settings.proto` to use `MiddleMultipleActions`
+- **Custom Settings:**
+ - Removed the `UNRECOGNIZED` enum from `MiddleNavigationAction`.
+ - Updated `visibleName` to use the name instead of having extra logic.
 -   **UI/UX Improvements:**
     -   Updated the settings UI to use the new settings management system.
     - Updated the settings UI to use the new settings management system.
     -   Updated `rememberMiddleNavigationAction` to use `multipleActions`.
-    - Added `MiddleMultipleActions` to hold two different actions.
-   - Added a method to get the proper seedColor.
+   - Added a method to get the proper `seedColor`.
+ - **Minor Changes:**
+  - Removed gson from the project.
+  - Added wire to the project.
+  - Updated `MiddleNavigationAction` to use `Multiple` instead of `UNRECOGNIZED`.
+  - Removed unnecessary comments.
+- Updated `MiddleNavigationItem` to use `MiddleNavigationAction`
+- Updated `getDataStore` to have a `producePath` lambda.
+- Added `BatteryPercent` to the new settings.
+- Added `NotificationSortBy` to the new settings.
+- Added `customUrls` to the new settings.
+- Added `showAll` to the new settings.
+- Added `shareChapter` to the new settings.
+- Added `historySave` to the new settings.
+- Added `showBlur` to the new settings.
+- Added `usePalette` to the new settings.
+- Added `amoledMode` to the new settings.
+- Updated `ThemeColor` to not include `UNRECOGNIZED`.
+- Added `rememberGridChoice`, `rememberThemeColor`, `rememberShowExpressiveness`, and `rememberMiddleMultipleActions`
+- Added `notifyOnReboot` to the new settings.
 -   **Remote Config:**
     - Updated `RemoteConfigKeys` to reflect the changes in settings.
 - **Misc:**
     - Updated `Multiplatform Roadmap.md`
-    - Fixed a crash when removing custom urls.
-    - Removed gson from the project.
-    - Added `MiddleMultipleActions` to hold two different actions.
-    - Updated `MiddleNavigationAction` to use `Multiple` instead of `UNRECOGNIZED`.
+    - Fixed a crash when removing custom urls.
     - Cleaned up code.
 - Refactored `SettingsHandling` to use `ProtoStoreHandler`
 - Updated `ProtoStoreHandler` to have a `set` and `get` function.
 - Updated `OtakuApp` to migrate the old settings to new settings.
 - Updated `OtakuApp` to create a protobuf data store.
 - Updated `settingsHandling` to use a lambda.
 - Updated `settingsHandling` to use the new protobuf data store.
-- Updated `getDataStore` to have a `producePath` lambda.
-Added `BatteryPercent` to the new settings.
-- Added `NotificationSortBy` to the new settings.
-Added `customUrls` to the new settings.
-- Added `showAll` to the new settings.
-- Added `shareChapter` to the new settings.
-- Added `historySave` to the new settings.
-- Added `showBlur` to the new settings.
-- Added `usePalette` to the new settings.
-- Added `amoledMode` to the new settings.
-- Updated `ThemeColor` to not include `UNRECOGNIZED`.
-- Added `rememberGridChoice`, `rememberThemeColor`, `rememberShowExpressiveness`, and `rememberMiddleMultipleActions`
-Changed `MiddleNavigationAction.UNRECOGNIZED` to just `MiddleNavigationAction.Multiple`
-- Updated `MiddleMultipleActions` to use `MiddleNavigationAction`
-Removed unnecessary comments.
-Updated `MiddleNavigationItem` to use `MiddleNavigationAction`
-Added `notifyOnReboot` to the new settings.
-Updated `settings.proto` to use `MiddleMultipleActions`
-Updated `settings.proto` to use `MiddleNavigationAction`