### PR TITLE
feat: Move Prerelease Repository and MoreInfoViewModel to kmpuiviews …

### DIFF
--- a/UIViews/src/main/java/com/programmersbox/uiviews/GenericInfo.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/GenericInfo.kt
@@ -8,13 +8,10 @@ import androidx.core.net.toUri
 import androidx.navigation.NavType
 import androidx.navigation.serialization.generateRouteWithArgs
 import com.programmersbox.kmpmodels.KmpItemModel
-import com.programmersbox.kmpuiviews.domain.AppUpdate
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.presentation.Screen
-import com.programmersbox.kmpuiviews.GenericInfo as KmpGenericInfo
 
 interface GenericInfo : KmpGenericInfo {
-
-    val apkString: AppUpdate.AppUpdates.() -> String?
 
     val deepLinkUri: String
 

--- a/UIViews/src/main/java/com/programmersbox/uiviews/checkers/DownloadAndInstallWorker.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/checkers/DownloadAndInstallWorker.kt
@@ -15,15 +15,16 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.programmersbox.kmpuiviews.utils.ConfirmationType
 import com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus
 import com.programmersbox.kmpuiviews.utils.DownloadAndInstaller
 import com.programmersbox.uiviews.utils.NotificationLogo
 import com.programmersbox.uiviews.utils.logFirebaseMessage
+import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import ru.solrudev.ackpine.session.parameters.Confirmation
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -45,7 +46,7 @@ class DownloadAndInstallWorker(
         runCatching {
             downloadAndInstaller.downloadAndInstall(
                 url = url,
-                confirmationType = Confirmation.IMMEDIATE
+                confirmationType = ConfirmationType.IMMEDIATE
             )
                 .onEach {
                     notify(notificationLogo, url) {
@@ -321,6 +322,7 @@ class DownloadWorker(
         fun downloadThenInstall(context: Context, url: String) {
             WorkManager.getInstance(context)
                 .beginWith(
+                    //TODO: Work on this
                     OneTimeWorkRequestBuilder<DownloadAndInstallWorker>()
                         .setInputData(workDataOf("url" to url))
                         .addTag("downloadAndInstall")
@@ -394,8 +396,8 @@ class InstallWorker(
 
         runCatching {
             downloadAndInstaller.install(
-                file = url,
-                confirmationType = Confirmation.IMMEDIATE
+                file = PlatformFile(url),
+                confirmationType = ConfirmationType.IMMEDIATE
             )
                 .onEach {
                     notify(notificationLogo, notificationId) {

--- a/UIViews/src/main/java/com/programmersbox/uiviews/checkers/DownloadAndInstallWorker.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/checkers/DownloadAndInstallWorker.kt
@@ -171,16 +171,16 @@ class DownloadAndInstallWorker(
                             DownloadAndInstallStatus.Error(it.progress.getString("error") ?: "Unknown error")
                         } else {
                             when (it.progress.getString("progress")) {
-                                "com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadAndInstallStatus\$Downloading" ->
+                                "com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus\$Downloading" ->
                                     DownloadAndInstallStatus.Downloading(it.progress.getFloat("progressAmount", 0f))
 
-                                "com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadAndInstallStatus\$Downloaded" ->
+                                "com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus\$Downloaded" ->
                                     DownloadAndInstallStatus.Downloaded
 
-                                "com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadAndInstallStatus\$Installing" ->
+                                "com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus\$Installing" ->
                                     DownloadAndInstallStatus.Installing
 
-                                "com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadAndInstallStatus\$Installed" ->
+                                "com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus\$Installed" ->
                                     DownloadAndInstallStatus.Installed
 
                                 else -> DownloadAndInstallStatus.Error(it.progress.getString("error") ?: "Unknown error")

--- a/UIViews/src/main/java/com/programmersbox/uiviews/di/RepositoryModule.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/di/RepositoryModule.kt
@@ -3,13 +3,11 @@ package com.programmersbox.uiviews.di
 import com.programmersbox.kmpuiviews.di.repositories
 import com.programmersbox.kmpuiviews.repository.NotificationRepository
 import com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadStateRepository
-import com.programmersbox.uiviews.presentation.settings.updateprerelease.PrereleaseRepository
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 
 fun Module.repository() {
     singleOf(::NotificationRepository)
-    singleOf(::PrereleaseRepository)
     singleOf(::DownloadStateRepository)
     includes(repositories)
 }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/di/ViewModelModule.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/di/ViewModelModule.kt
@@ -7,7 +7,6 @@ import com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadSt
 import com.programmersbox.uiviews.presentation.settings.extensions.ExtensionListViewModel
 import com.programmersbox.uiviews.presentation.settings.updateprerelease.PrereleaseViewModel
 import com.programmersbox.uiviews.presentation.settings.viewmodels.AccountViewModel
-import com.programmersbox.uiviews.presentation.settings.viewmodels.MoreInfoViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 
@@ -15,7 +14,6 @@ fun Module.viewModels() {
     viewModelOf(::ExtensionListViewModel)
     viewModelOf(::HistoryViewModel)
     viewModelOf(::DetailsViewModel)
-    viewModelOf(::MoreInfoViewModel)
     viewModelOf(::PrereleaseViewModel)
     viewModelOf(::DownloadStateViewModel)
     viewModelOf(::AccountViewModel)

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/NavGraph.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/NavGraph.kt
@@ -196,7 +196,7 @@ private fun NavGraphBuilder.settings(
             trackScreen(Screen.MoreInfoSettings)
             InfoSettings(
                 usedLibraryClick = { navController.navigate(Screen.AboutScreen) { launchSingleTop = true } },
-                onPreleaseClick = { navController.navigate(Screen.PrereleaseScreen) { launchSingleTop = true } },
+                onPrereleaseClick = { navController.navigate(Screen.PrereleaseScreen) { launchSingleTop = true } },
             )
         }
 

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/InfoSettings.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/InfoSettings.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.FragmentActivity
@@ -43,15 +42,14 @@ import com.programmersbox.kmpuiviews.presentation.Screen
 import com.programmersbox.kmpuiviews.presentation.components.PreferenceSetting
 import com.programmersbox.kmpuiviews.presentation.components.ShowWhen
 import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
+import com.programmersbox.kmpuiviews.presentation.settings.moreinfo.MoreInfoViewModel
 import com.programmersbox.kmpuiviews.utils.LocalNavController
 import com.programmersbox.kmpuiviews.utils.composables.icons.Discord
 import com.programmersbox.kmpuiviews.utils.composables.icons.Github
 import com.programmersbox.sharedutils.AppLogo
 import com.programmersbox.uiviews.BuildConfig
 import com.programmersbox.uiviews.R
-import com.programmersbox.uiviews.presentation.settings.viewmodels.MoreInfoViewModel
 import com.programmersbox.uiviews.utils.LightAndDarkPreviews
-import com.programmersbox.uiviews.utils.LocalGenericInfo
 import com.programmersbox.uiviews.utils.PreviewTheme
 import com.programmersbox.uiviews.utils.appVersion
 import com.programmersbox.uiviews.utils.versionCode
@@ -68,10 +66,8 @@ fun InfoSettings(
     onPreleaseClick: () -> Unit,
 ) {
     val activity = LocalActivity.current
-    val genericInfo = LocalGenericInfo.current
     val navController = LocalNavController.current
     val scope = rememberCoroutineScope()
-    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val dataStoreHandling = koinInject<DataStoreHandling>()
     val appUpdateCheck: AppUpdateCheck = koinInject()
@@ -168,7 +164,7 @@ fun InfoSettings(
                     )
                 }
             },
-            modifier = Modifier.clickable { scope.launch(Dispatchers.IO) { infoViewModel.updateChecker(context) } }
+            modifier = Modifier.clickable { scope.launch(Dispatchers.IO) { infoViewModel.updateChecker() } }
         )
 
         ShowWhen(

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/InfoSettings.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/InfoSettings.kt
@@ -1,232 +1,23 @@
 package com.programmersbox.uiviews.presentation.settings
 
-import android.Manifest
-import androidx.activity.compose.LocalActivity
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.LibraryBooks
-import androidx.compose.material.icons.filled.AttachMoney
-import androidx.compose.material.icons.filled.Bento
-import androidx.compose.material.icons.filled.CatchingPokemon
-import androidx.compose.material.icons.filled.SystemUpdateAlt
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.stringResource
-import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import com.programmersbox.datastore.DataStoreHandling
-import com.programmersbox.datastore.asState
-import com.programmersbox.helpfulutils.requestPermissions
-import com.programmersbox.kmpuiviews.domain.AppUpdate
-import com.programmersbox.kmpuiviews.domain.AppUpdateCheck
-import com.programmersbox.kmpuiviews.platform
-import com.programmersbox.kmpuiviews.presentation.Screen
-import com.programmersbox.kmpuiviews.presentation.components.PreferenceSetting
-import com.programmersbox.kmpuiviews.presentation.components.ShowWhen
-import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
-import com.programmersbox.kmpuiviews.presentation.settings.moreinfo.MoreInfoViewModel
-import com.programmersbox.kmpuiviews.utils.LocalNavController
-import com.programmersbox.kmpuiviews.utils.composables.icons.Discord
-import com.programmersbox.kmpuiviews.utils.composables.icons.Github
-import com.programmersbox.sharedutils.AppLogo
+import com.programmersbox.kmpuiviews.presentation.settings.moreinfo.MoreInfoScreen
 import com.programmersbox.uiviews.BuildConfig
-import com.programmersbox.uiviews.R
 import com.programmersbox.uiviews.utils.LightAndDarkPreviews
 import com.programmersbox.uiviews.utils.PreviewTheme
-import com.programmersbox.uiviews.utils.appVersion
-import com.programmersbox.uiviews.utils.versionCode
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import org.koin.androidx.compose.koinViewModel
-import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InfoSettings(
-    infoViewModel: MoreInfoViewModel = koinViewModel(),
     usedLibraryClick: () -> Unit,
-    onPreleaseClick: () -> Unit,
+    onPrereleaseClick: () -> Unit,
 ) {
-    val activity = LocalActivity.current
-    val navController = LocalNavController.current
-    val scope = rememberCoroutineScope()
-    val uriHandler = LocalUriHandler.current
-    val dataStoreHandling = koinInject<DataStoreHandling>()
-    val appUpdateCheck: AppUpdateCheck = koinInject()
-
-    SettingsScaffold(stringResource(R.string.more_info_category)) {
-        PreferenceSetting(
-            settingTitle = { Text(stringResource(R.string.view_libraries_used)) },
-            settingIcon = { Icon(Icons.AutoMirrored.Filled.LibraryBooks, null, modifier = Modifier.fillMaxSize()) },
-            modifier = Modifier.clickable(
-                indication = ripple(),
-                interactionSource = null,
-                onClick = usedLibraryClick
-            )
-        )
-
-        var onboarding by dataStoreHandling.hasGoneThroughOnboarding.asState()
-        PreferenceSetting(
-            settingTitle = { Text("View Onboarding Again") },
-            settingIcon = { Icon(Icons.Default.CatchingPokemon, null) },
-            modifier = Modifier.clickable(
-                indication = ripple(),
-                interactionSource = null
-            ) {
-                navController.clearBackStack<Screen.RecentScreen>()
-                onboarding = false
-                navController.navigate(Screen.OnboardingScreen) {
-                    popUpTo(Screen.RecentScreen) {
-                        inclusive = true
-                    }
-                }
-            }
-        )
-
-        PreferenceSetting(
-            settingTitle = { Text(stringResource(R.string.view_on_github)) },
-            settingIcon = { Icon(Icons.Github, null, modifier = Modifier.fillMaxSize()) },
-            modifier = Modifier.clickable(
-                indication = ripple(),
-                interactionSource = null
-            ) { uriHandler.openUri("https://github.com/jakepurple13/OtakuWorld/releases/latest") }
-        )
-
-        if (BuildConfig.IS_PRERELEASE || BuildConfig.DEBUG) {
-            PreferenceSetting(
-                settingTitle = { Text("Update to latest pre release") },
-                settingIcon = { Icon(Icons.Default.Bento, null, modifier = Modifier.fillMaxSize()) },
-                modifier = Modifier.clickable(
-                    indication = ripple(),
-                    interactionSource = null,
-                    onClick = onPreleaseClick
-                )
-            )
-        }
-
-        PreferenceSetting(
-            settingTitle = { Text(stringResource(R.string.join_discord)) },
-            settingIcon = { Icon(Icons.Discord, null, modifier = Modifier.fillMaxSize()) },
-            modifier = Modifier.clickable(
-                indication = ripple(),
-                interactionSource = null
-            ) { uriHandler.openUri("https://discord.gg/MhhHMWqryg") }
-        )
-
-        PreferenceSetting(
-            settingTitle = { Text(stringResource(R.string.support)) },
-            summaryValue = { Text(stringResource(R.string.support_summary)) },
-            settingIcon = { Icon(Icons.Default.AttachMoney, null, modifier = Modifier.fillMaxSize()) },
-            modifier = Modifier.clickable(
-                indication = ripple(),
-                interactionSource = null
-            ) { uriHandler.openUri("https://ko-fi.com/V7V3D3JI") }
-        )
-
-        val appUpdate by appUpdateCheck.updateAppCheck.collectAsStateWithLifecycle(null)
-
-        PreferenceSetting(
-            settingIcon = {
-                Image(
-                    rememberDrawablePainter(drawable = koinInject<AppLogo>().logo),
-                    null,
-                    modifier = Modifier.fillMaxSize()
-                )
-            },
-            settingTitle = {
-                Column {
-                    Text(
-                        "Version code: ${versionCode()}",
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                    Text(stringResource(R.string.currentVersion, appVersion()))
-                    Text(
-                        platform(),
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                }
-            },
-            modifier = Modifier.clickable { scope.launch(Dispatchers.IO) { infoViewModel.updateChecker() } }
-        )
-
-        ShowWhen(
-            visibility = AppUpdate.checkForUpdate(appVersion(), appUpdate?.updateRealVersion.orEmpty())
-        ) {
-            var showDialog by remember { mutableStateOf(false) }
-
-            if (showDialog) {
-                AlertDialog(
-                    onDismissRequest = { showDialog = false },
-                    title = { Text(stringResource(R.string.updateTo, appUpdate?.updateRealVersion.orEmpty())) },
-                    text = { Text(stringResource(R.string.please_update_for_latest_features)) },
-                    confirmButton = {
-                        TextButton(
-                            onClick = {
-                                (activity as? FragmentActivity)?.requestPermissions(
-                                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                                    Manifest.permission.READ_EXTERNAL_STORAGE
-                                ) {
-                                    if (it.isGranted) {
-                                        appUpdateCheck
-                                            .updateAppCheck
-                                            .value
-                                            ?.let { a ->
-                                                infoViewModel.update(a)
-                                            }
-                                    }
-                                }
-                                showDialog = false
-                            }
-                        ) { Text(stringResource(R.string.update)) }
-                    },
-                    dismissButton = {
-                        TextButton(onClick = { showDialog = false }) { Text(stringResource(R.string.notNow)) }
-                        TextButton(
-                            onClick = {
-                                uriHandler.openUri("https://github.com/jakepurple13/OtakuWorld/releases/latest")
-                                showDialog = false
-                            }
-                        ) { Text(stringResource(R.string.gotoBrowser)) }
-                    }
-                )
-            }
-
-            PreferenceSetting(
-                settingTitle = { Text(stringResource(R.string.update_available)) },
-                summaryValue = { Text(stringResource(R.string.updateTo, appUpdate?.updateRealVersion.orEmpty())) },
-                modifier = Modifier.clickable(
-                    indication = ripple(),
-                    interactionSource = null
-                ) { showDialog = true },
-                settingIcon = {
-                    Icon(
-                        Icons.Default.SystemUpdateAlt,
-                        null,
-                        tint = Color(0xFF00E676),
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
-            )
-        }
-    }
+    MoreInfoScreen(
+        usedLibraryClick = usedLibraryClick,
+        onPrereleaseClick = onPrereleaseClick,
+        shouldShowPrerelease = BuildConfig.DEBUG
+    )
 }
 
 @LightAndDarkPreviews
@@ -235,7 +26,7 @@ private fun InfoSettingsPreview() {
     PreviewTheme {
         InfoSettings(
             usedLibraryClick = {},
-            onPreleaseClick = {}
+            onPrereleaseClick = {}
         )
     }
 }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/downloadstate/DownloadStateRepository.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/downloadstate/DownloadStateRepository.kt
@@ -6,6 +6,7 @@ import androidx.work.WorkManager
 import com.programmersbox.kmpuiviews.utils.DownloadAndInstaller
 import com.programmersbox.uiviews.checkers.DownloadAndInstallWorker
 import com.programmersbox.uiviews.checkers.DownloadWorker
+import io.github.vinceglb.filekit.PlatformFile
 import java.io.File
 import java.util.UUID
 
@@ -20,8 +21,9 @@ class DownloadStateRepository(
         workManager.cancelWorkById(id)
     }
 
-    fun install(url: String) =
-        downloadAndInstaller.install(File(context.cacheDir, "${url.toUri().lastPathSegment}.apk"))
+    fun install(url: String) = downloadAndInstaller.install(
+        PlatformFile(File(context.cacheDir, "${url.toUri().lastPathSegment}.apk"))
+    )
 
     fun downloadAndInstall(url: String) {
         DownloadAndInstallWorker.downloadAndInstall(context, url)

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/updateprerelease/PrereleaseViewModel.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/settings/updateprerelease/PrereleaseViewModel.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.programmersbox.kmpuiviews.repository.GitHubPrerelease
+import com.programmersbox.kmpuiviews.repository.PrereleaseRepository
 import com.programmersbox.kmpuiviews.utils.DownloadAndInstallStatus
 import com.programmersbox.uiviews.presentation.settings.downloadstate.DownloadStateRepository
 import kotlinx.coroutines.flow.launchIn

--- a/UIViews/src/main/java/com/programmersbox/uiviews/utils/MockData.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/utils/MockData.kt
@@ -51,6 +51,7 @@ import com.programmersbox.kmpmodels.KmpApiService
 import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.di.databases
 import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.utils.ComponentState
@@ -70,6 +71,7 @@ import com.programmersbox.uiviews.presentation.components.M3CoverCard
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.compose.KoinIsolatedContext
+import org.koin.dsl.binds
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import java.util.Locale
@@ -189,7 +191,10 @@ fun PreviewTheme(
                 single { AppLogo(AppCompatResources.getDrawable(context, R.drawable.ic_site_settings)!!, R.drawable.ic_site_settings) }
             }
             module {
-                single<GenericInfo> { MockInfo(get()) }
+                single<GenericInfo> { MockInfo(get()) } binds arrayOf(
+                    KmpGenericInfo::class,
+                    GenericInfo::class
+                )
                 repository()
                 includes(databases)
                 single { SourceLoader(context.applicationContext as Application, context, get<GenericInfo>().sourceType, get()) }

--- a/animeworld/src/main/java/com/programmersbox/animeworld/GenericAnime.kt
+++ b/animeworld/src/main/java/com/programmersbox/animeworld/GenericAnime.kt
@@ -90,6 +90,7 @@ import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
 import com.programmersbox.kmpmodels.KmpStorage
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.presentation.components.PreferenceSetting
 import com.programmersbox.kmpuiviews.presentation.components.ShowWhen
@@ -115,10 +116,14 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
-    single<GenericInfo> { GenericAnime(get(), get(), get()) }
+    single<GenericInfo> { GenericAnime(get(), get(), get()) } binds arrayOf(
+        KmpGenericInfo::class,
+        GenericInfo::class
+    )
     single { NotificationLogo(R.mipmap.ic_launcher_foreground) }
     single { StorageHolder() }
     single { AnimeDataStoreHandling() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     id("com.squareup.wire") version "5.3.1" apply false
     id("org.jetbrains.compose.hot-reload") version "1.0.0-alpha09" apply false
+    alias(libs.plugins.buildKonfig) apply false
 }
 
 projectInfo {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,8 @@ connectivity = "2.0.0"
 cmpLifecycle = "2.9.0-alpha07"
 navigationCmp = "2.9.0-alpha17"
 
+buildKonfig = "0.17.1"
+
 [plugins]
 kotlinGradle = { id = "org.jetbrains.kotlin:kotlin.gradle.plugin", version.ref = "kotlin" }
 kotlinSerializationGradle = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -117,6 +119,7 @@ room = { id = "androidx.room", version.ref = "roomVersion" }
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "gradle" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
 
 [libraries]
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "cmpLifecycle" }

--- a/kmpuiviews/build.gradle.kts
+++ b/kmpuiviews/build.gradle.kts
@@ -1,9 +1,12 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.BOOLEAN
+
 plugins {
     `otaku-multiplatform`
     alias(libs.plugins.ksp)
     id("kotlinx-serialization")
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.buildKonfig)
 }
 
 otakuDependencies {
@@ -127,5 +130,23 @@ kotlin {
                 implementation(libs.connectivity.compose.http)
             }
         }
+    }
+}
+
+buildkonfig {
+    packageName = "com.programmersbox.kmpuiviews"
+
+    defaultConfigs {
+        buildConfigField(
+            type = BOOLEAN,
+            const = true,
+            name = "IS_PRERELEASE",
+            value = runCatching { System.getenv("IS_PRERELEASE") }
+                .onFailure { it.printStackTrace() }
+                .mapCatching { it.toBoolean() }
+                .getOrDefault(false)
+                .toString()
+                .also { println("IS_PRERELEASE: $it") }
+        )
     }
 }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.kt
@@ -13,12 +13,15 @@ import com.programmersbox.favoritesdatabase.DbModel
 import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
+import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.utils.ComponentState
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 
-interface GenericInfo {
+interface KmpGenericInfo {
     val scrollBuffer: Int get() = 2
     val sourceType: String get() = ""
+
+    val apkString: AppUpdate.AppUpdates.() -> String?
 
     fun chapterOnClick(
         model: KmpChapterModel,

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/di/RepositoryModule.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import com.programmersbox.kmpmodels.SourceRepository
 import com.programmersbox.kmpuiviews.repository.ChangingSettingsRepository
 import com.programmersbox.kmpuiviews.repository.CurrentSourceRepository
 import com.programmersbox.kmpuiviews.repository.FavoritesRepository
+import com.programmersbox.kmpuiviews.repository.PrereleaseRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -12,4 +13,5 @@ val repositories = module {
     singleOf(::CurrentSourceRepository)
     singleOf(::ChangingSettingsRepository)
     singleOf(::FavoritesRepository)
+    singleOf(::PrereleaseRepository)
 }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/di/ViewModelModule.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/di/ViewModelModule.kt
@@ -12,6 +12,7 @@ import com.programmersbox.kmpuiviews.presentation.settings.lists.OtakuCustomList
 import com.programmersbox.kmpuiviews.presentation.settings.lists.OtakuListViewModel
 import com.programmersbox.kmpuiviews.presentation.settings.lists.imports.ImportFullListViewModel
 import com.programmersbox.kmpuiviews.presentation.settings.lists.imports.ImportListViewModel
+import com.programmersbox.kmpuiviews.presentation.settings.moreinfo.MoreInfoViewModel
 import com.programmersbox.kmpuiviews.presentation.settings.moresettings.MoreSettingsViewModel
 import com.programmersbox.kmpuiviews.presentation.settings.notifications.NotificationSettingsViewModel
 import org.koin.core.module.Module
@@ -32,6 +33,7 @@ val viewModels: Module = module {
     viewModelOf(::OtakuListViewModel)
     viewModelOf(::MoreSettingsViewModel)
     viewModelOf(::SettingViewModel)
+    viewModelOf(::MoreInfoViewModel)
 
     viewModel { OtakuCustomListViewModel(get(), get<DataStoreHandling>().showBySource) }
 }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/moreinfo/MoreInfoScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/moreinfo/MoreInfoScreen.kt
@@ -1,0 +1,234 @@
+package com.programmersbox.kmpuiviews.presentation.settings.moreinfo
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.LibraryBooks
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Bento
+import androidx.compose.material.icons.filled.CatchingPokemon
+import androidx.compose.material.icons.filled.SystemUpdateAlt
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.datastore.DataStoreHandling
+import com.programmersbox.datastore.asState
+import com.programmersbox.kmpuiviews.BuildKonfig
+import com.programmersbox.kmpuiviews.appVersion
+import com.programmersbox.kmpuiviews.domain.AppUpdate
+import com.programmersbox.kmpuiviews.domain.AppUpdateCheck
+import com.programmersbox.kmpuiviews.painterLogo
+import com.programmersbox.kmpuiviews.platform
+import com.programmersbox.kmpuiviews.presentation.Screen
+import com.programmersbox.kmpuiviews.presentation.components.PreferenceSetting
+import com.programmersbox.kmpuiviews.presentation.components.ShowWhen
+import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
+import com.programmersbox.kmpuiviews.utils.LocalNavController
+import com.programmersbox.kmpuiviews.utils.composables.icons.Discord
+import com.programmersbox.kmpuiviews.utils.composables.icons.Github
+import com.programmersbox.kmpuiviews.versionCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+import otakuworld.kmpuiviews.generated.resources.Res
+import otakuworld.kmpuiviews.generated.resources.currentVersion
+import otakuworld.kmpuiviews.generated.resources.gotoBrowser
+import otakuworld.kmpuiviews.generated.resources.join_discord
+import otakuworld.kmpuiviews.generated.resources.more_info_category
+import otakuworld.kmpuiviews.generated.resources.notNow
+import otakuworld.kmpuiviews.generated.resources.please_update_for_latest_features
+import otakuworld.kmpuiviews.generated.resources.support
+import otakuworld.kmpuiviews.generated.resources.support_summary
+import otakuworld.kmpuiviews.generated.resources.update
+import otakuworld.kmpuiviews.generated.resources.updateTo
+import otakuworld.kmpuiviews.generated.resources.update_available
+import otakuworld.kmpuiviews.generated.resources.view_libraries_used
+import otakuworld.kmpuiviews.generated.resources.view_on_github
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoreInfoScreen(
+    infoViewModel: MoreInfoViewModel = koinViewModel(),
+    usedLibraryClick: () -> Unit,
+    onPrereleaseClick: () -> Unit,
+    shouldShowPrerelease: Boolean,
+) {
+    val navController = LocalNavController.current
+    val scope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
+    val dataStoreHandling = koinInject<DataStoreHandling>()
+    val appUpdateCheck: AppUpdateCheck = koinInject()
+
+    SettingsScaffold(stringResource(Res.string.more_info_category)) {
+        PreferenceSetting(
+            settingTitle = { Text(stringResource(Res.string.view_libraries_used)) },
+            settingIcon = { Icon(Icons.AutoMirrored.Filled.LibraryBooks, null, modifier = Modifier.fillMaxSize()) },
+            modifier = Modifier.clickable(
+                indication = ripple(),
+                interactionSource = null,
+                onClick = usedLibraryClick
+            )
+        )
+
+        var onboarding by dataStoreHandling.hasGoneThroughOnboarding.asState()
+        PreferenceSetting(
+            settingTitle = { Text("View Onboarding Again") },
+            settingIcon = { Icon(Icons.Default.CatchingPokemon, null) },
+            modifier = Modifier.clickable(
+                indication = ripple(),
+                interactionSource = null
+            ) {
+                navController.clearBackStack<Screen.RecentScreen>()
+                onboarding = false
+                navController.navigate(Screen.OnboardingScreen) {
+                    popUpTo(Screen.RecentScreen) {
+                        inclusive = true
+                    }
+                }
+            }
+        )
+
+        PreferenceSetting(
+            settingTitle = { Text(stringResource(Res.string.view_on_github)) },
+            settingIcon = { Icon(Icons.Github, null, modifier = Modifier.fillMaxSize()) },
+            modifier = Modifier.clickable(
+                indication = ripple(),
+                interactionSource = null
+            ) { uriHandler.openUri("https://github.com/jakepurple13/OtakuWorld/releases/latest") }
+        )
+
+        if (BuildKonfig.IS_PRERELEASE || shouldShowPrerelease) {
+            PreferenceSetting(
+                settingTitle = { Text("Update to latest pre release") },
+                settingIcon = { Icon(Icons.Default.Bento, null, modifier = Modifier.fillMaxSize()) },
+                modifier = Modifier.clickable(
+                    indication = ripple(),
+                    interactionSource = null,
+                    onClick = onPrereleaseClick
+                )
+            )
+        }
+
+        PreferenceSetting(
+            settingTitle = { Text(stringResource(Res.string.join_discord)) },
+            settingIcon = { Icon(Icons.Discord, null, modifier = Modifier.fillMaxSize()) },
+            modifier = Modifier.clickable(
+                indication = ripple(),
+                interactionSource = null
+            ) { uriHandler.openUri("https://discord.gg/MhhHMWqryg") }
+        )
+
+        PreferenceSetting(
+            settingTitle = { Text(stringResource(Res.string.support)) },
+            summaryValue = { Text(stringResource(Res.string.support_summary)) },
+            settingIcon = { Icon(Icons.Default.AttachMoney, null, modifier = Modifier.fillMaxSize()) },
+            modifier = Modifier.clickable(
+                indication = ripple(),
+                interactionSource = null
+            ) { uriHandler.openUri("https://ko-fi.com/V7V3D3JI") }
+        )
+
+        val appUpdate by appUpdateCheck.updateAppCheck.collectAsStateWithLifecycle(null)
+
+        PreferenceSetting(
+            settingIcon = {
+                Image(
+                    painterLogo(),
+                    null,
+                    modifier = Modifier.fillMaxSize()
+                )
+            },
+            settingTitle = {
+                Column {
+                    Text(
+                        "Version code: ${versionCode()}",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    Text(stringResource(Res.string.currentVersion, appVersion()))
+                    Text(
+                        platform(),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+            },
+            modifier = Modifier.clickable { scope.launch(Dispatchers.IO) { infoViewModel.updateChecker() } }
+        )
+
+        ShowWhen(
+            visibility = AppUpdate.checkForUpdate(appVersion(), appUpdate?.updateRealVersion.orEmpty())
+        ) {
+            var showDialog by remember { mutableStateOf(false) }
+
+            if (showDialog) {
+                AlertDialog(
+                    onDismissRequest = { showDialog = false },
+                    title = { Text(stringResource(Res.string.updateTo, appUpdate?.updateRealVersion.orEmpty())) },
+                    text = { Text(stringResource(Res.string.please_update_for_latest_features)) },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                /*(activity as? FragmentActivity)?.requestPermissions(
+                                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                                    Manifest.permission.READ_EXTERNAL_STORAGE
+                                ) {
+                                    if (it.isGranted) {
+                                        appUpdateCheck
+                                            .updateAppCheck
+                                            .value
+                                            ?.let { a -> infoViewModel.update(a) }
+                                    }
+                                }*/
+                                showDialog = false
+                            }
+                        ) { Text(stringResource(Res.string.update)) }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showDialog = false }) { Text(stringResource(Res.string.notNow)) }
+                        TextButton(
+                            onClick = {
+                                uriHandler.openUri("https://github.com/jakepurple13/OtakuWorld/releases/latest")
+                                showDialog = false
+                            }
+                        ) { Text(stringResource(Res.string.gotoBrowser)) }
+                    }
+                )
+            }
+
+            PreferenceSetting(
+                settingTitle = { Text(stringResource(Res.string.update_available)) },
+                summaryValue = { Text(stringResource(Res.string.updateTo, appUpdate?.updateRealVersion.orEmpty())) },
+                modifier = Modifier.clickable(
+                    indication = ripple(),
+                    interactionSource = null
+                ) { showDialog = true },
+                settingIcon = {
+                    Icon(
+                        Icons.Default.SystemUpdateAlt,
+                        null,
+                        tint = Color(0xFF00E676),
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            )
+        }
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/moreinfo/MoreInfoViewModel.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/moreinfo/MoreInfoViewModel.kt
@@ -1,30 +1,26 @@
-package com.programmersbox.uiviews.presentation.settings.viewmodels
+package com.programmersbox.kmpuiviews.presentation.settings.moreinfo
 
-import android.content.Context
-import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.domain.AppUpdateCheck
 import com.programmersbox.kmpuiviews.utils.DownloadAndInstaller
-import com.programmersbox.uiviews.GenericInfo
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 class MoreInfoViewModel(
     val downloadAndInstaller: DownloadAndInstaller,
-    private val genericInfo: GenericInfo,
+    private val genericInfo: KmpGenericInfo,
     private val appUpdateCheck: AppUpdateCheck,
 ) : ViewModel() {
 
+    @OptIn(ExperimentalAtomicApi::class)
     private val checker = AtomicBoolean(false)
 
-    fun update(
-        a: AppUpdate.AppUpdates,
-    ) {
+    fun update(a: AppUpdate.AppUpdates) {
         viewModelScope.launch {
             val url = a.downloadUrl(genericInfo.apkString)
 
@@ -37,17 +33,17 @@ class MoreInfoViewModel(
         }
     }
 
-    suspend fun updateChecker(context: Context) {
+    @OptIn(ExperimentalAtomicApi::class)
+    suspend fun updateChecker() {
         try {
-            if (!checker.get()) {
-                checker.set(true)
+            if (!checker.load()) {
+                checker.store(true)
                 AppUpdate.getUpdate()?.let(appUpdateCheck.updateAppCheck::tryEmit)
             }
         } catch (e: Exception) {
             e.printStackTrace()
         } finally {
-            checker.set(false)
-            withContext(Dispatchers.Main) { context.let { c -> Toast.makeText(c, "Done Checking", Toast.LENGTH_SHORT).show() } }
+            checker.store(false)
         }
     }
 }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/repository/PrereleaseRepository.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/repository/PrereleaseRepository.kt
@@ -1,6 +1,5 @@
-package com.programmersbox.uiviews.presentation.settings.updateprerelease
+package com.programmersbox.kmpuiviews.repository
 
-import android.content.Context
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -11,9 +10,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-class PrereleaseRepository(
-    context: Context,
-) {
+class PrereleaseRepository {
     private val client = HttpClient {
         install(ContentNegotiation) {
             json(

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/DownloadAndInstaller.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/DownloadAndInstaller.kt
@@ -1,0 +1,48 @@
+package com.programmersbox.kmpuiviews.utils
+
+import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+expect class DownloadAndInstaller {
+    suspend fun uninstall(packageName: String)
+
+    fun downloadAndInstall(
+        url: String,
+        destinationPath: String = "",
+        confirmationType: ConfirmationType = ConfirmationType.IMMEDIATE,
+    ): Flow<DownloadAndInstallStatus>
+
+    fun download(
+        url: String,
+        destinationPath: String = "",
+    ): Flow<DownloadAndInstallStatus>
+
+    fun install(
+        file: PlatformFile,
+        confirmationType: ConfirmationType = ConfirmationType.IMMEDIATE,
+    ): Flow<DownloadAndInstallStatus>
+}
+
+@Serializable
+sealed class DownloadAndInstallStatus {
+    @Serializable
+    data class Downloading(val progress: Float) : DownloadAndInstallStatus()
+
+    @Serializable
+    data object Downloaded : DownloadAndInstallStatus()
+
+    @Serializable
+    data object Installing : DownloadAndInstallStatus()
+
+    @Serializable
+    data object Installed : DownloadAndInstallStatus()
+
+    @Serializable
+    data class Error(val message: String) : DownloadAndInstallStatus()
+}
+
+enum class ConfirmationType {
+    IMMEDIATE,
+    DEFERRED
+}

--- a/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/GenericMangaDesktop.kt
+++ b/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/GenericMangaDesktop.kt
@@ -15,13 +15,16 @@ import com.programmersbox.favoritesdatabase.DbModel
 import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
-import com.programmersbox.kmpuiviews.GenericInfo
+import com.programmersbox.kmpuiviews.KmpGenericInfo
+import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.utils.ComponentState
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 
 class GenericMangaDesktop(
     val settingsHandling: NewSettingsHandling,
-) : GenericInfo {
+) : KmpGenericInfo {
+
+    override val apkString: AppUpdate.AppUpdates.() -> String? = { "" }
 
     override val sourceType: String get() = "manga"
 

--- a/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/main.kt
+++ b/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/main.kt
@@ -20,9 +20,8 @@ fun main() = application {
                     single {
                         NewSettingsHandling(
                             createProtobuf(
-                                serializer = SettingsSerializer(true)
+                                serializer = SettingsSerializer()
                             ),
-                            canShowBlur = true
                         )
                     }
 

--- a/mangaworld/src/main/java/com/programmersbox/mangaworld/GenericManga.kt
+++ b/mangaworld/src/main/java/com/programmersbox/mangaworld/GenericManga.kt
@@ -48,6 +48,7 @@ import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
 import com.programmersbox.kmpmodels.KmpStorage
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.presentation.components.PreferenceSetting
 import com.programmersbox.kmpuiviews.utils.ComponentState
@@ -86,11 +87,15 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.binds
 import org.koin.dsl.module
 import java.io.File
 
 val appModule = module {
-    single<GenericInfo> { GenericManga(get(), get(), get(), get()) }
+    single<GenericInfo> { GenericManga(get(), get(), get(), get()) } binds arrayOf(
+        KmpGenericInfo::class,
+        GenericInfo::class
+    )
     singleOf(::NetworkHelper)
     single { NotificationLogo(R.drawable.manga_world_round_logo) }
     singleOf(::ChapterHolder)

--- a/novelworld/src/main/java/com/programmersbox/novelworld/GenericNovel.kt
+++ b/novelworld/src/main/java/com/programmersbox/novelworld/GenericNovel.kt
@@ -40,6 +40,7 @@ import com.programmersbox.helpfulutils.defaultSharedPref
 import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
 import com.programmersbox.kmpmodels.KmpItemModel
+import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.domain.AppUpdate
 import com.programmersbox.kmpuiviews.utils.ComponentState
 import com.programmersbox.uiviews.BuildType
@@ -52,10 +53,14 @@ import com.programmersbox.uiviews.utils.ChapterModelSerializer
 import com.programmersbox.uiviews.utils.NotificationLogo
 import com.programmersbox.uiviews.utils.combineClickableWithIndication
 import com.programmersbox.uiviews.utils.trackScreen
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val appModule = module {
-    single<GenericInfo> { GenericNovel(get()) }
+    single<GenericInfo> { GenericNovel(get()) } binds arrayOf(
+        KmpGenericInfo::class,
+        GenericInfo::class
+    )
     single { NotificationLogo(R.mipmap.ic_launcher_foreground) }
 }
 


### PR DESCRIPTION
…and Update Dependencies

This commit moves the `PrereleaseRepository` and `MoreInfoViewModel` to the `kmpuiviews` module for multiplatform use, updates related dependencies, and adds a `DownloadAndInstaller` to kmp.

-   **Prerelease Repository:**
    -   Moved `PrereleaseRepository` to `kmpuiviews`.
    - Added `GitHubPrerelease` and `GitHubAssets` for api data
-   **MoreInfoViewModel:**
    -   Moved `MoreInfoViewModel` to `kmpuiviews`.
    - Added the ability to download and install the apk from GitHub
    - Updated `GenericInfo` to `KmpGenericInfo`
    - Updated `appModule` in each project to include `KmpGenericInfo` and `GenericInfo`
- **Other**
+   - Added `DownloadAndInstaller` to kmp
+   - Added `DownloadAndInstallStatus` and `ConfirmationType` to kmp
    -   Updated the DI modules to reflect these changes.
    - Added `PrereleaseRepository` to the di
    - Added `androidFile` to `PlatformFile`
-   - General cleanup.
-   - Added `androidFile` to `PlatformFile`
+   - General cleanup.