### PR TITLE
Refactor: Enable Nav3 and migrate navigation logic to KMP

### DIFF
--- a/UIViews/src/main/java/com/programmersbox/uiviews/GenericInfo.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/GenericInfo.kt
@@ -1,15 +1,17 @@
 package com.programmersbox.uiviews
 
-import androidx.navigation3.runtime.EntryProviderScope
-import androidx.navigation3.runtime.NavKey
+import androidx.compose.runtime.Composable
 import com.programmersbox.kmpuiviews.PlatformGenericInfo
+import com.programmersbox.uiviews.presentation.settings.viewmodels.AccountViewModel
+import org.koin.androidx.compose.koinViewModel
 
 interface GenericInfo : PlatformGenericInfo {
-    context(navGraph: EntryProviderScope<NavKey>)
-    fun globalNav3Setup() {
-    }
+    @Composable
+    override fun AccountContent() = com.programmersbox.uiviews.presentation.onboarding.AccountContent()
 
-    context(navGraph: EntryProviderScope<NavKey>)
-    fun settingsNav3Setup() {
-    }
+    @Composable
+    override fun AccountSettings() = com.programmersbox.uiviews.presentation.settings.AccountSettings()
+
+    @Composable
+    override fun ProfileIcon(): String = koinViewModel<AccountViewModel>().accountInfo?.photoUrl?.toString().orEmpty()
 }

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/navigation/NavGraphView.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/navigation/NavGraphView.kt
@@ -1,38 +1,20 @@
 package com.programmersbox.uiviews.presentation.navigation
 
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation3.runtime.NavEntry
-import androidx.navigation3.runtime.NavEntryDecorator
-import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.ui.LocalNavAnimatedContentScope
-import androidx.navigation3.ui.NavDisplay
 import com.programmersbox.kmpuiviews.BuildType
-import com.programmersbox.kmpuiviews.analyticsScreen
-import com.programmersbox.kmpuiviews.logFirebaseMessage
 import com.programmersbox.kmpuiviews.presentation.Screen
 import com.programmersbox.kmpuiviews.presentation.navactions.Navigation3Actions
 import com.programmersbox.kmpuiviews.presentation.navactions.NavigationActions
 import com.programmersbox.kmpuiviews.presentation.navigation.AddBreadcrumbLogging
+import com.programmersbox.kmpuiviews.presentation.navigation.Nav3
 import com.programmersbox.kmpuiviews.presentation.navigation.navGraph
 import com.programmersbox.kmpuiviews.presentation.onboarding.OnboardingScreen
 import com.programmersbox.kmpuiviews.presentation.settings.SettingScreen
@@ -41,7 +23,6 @@ import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import com.programmersbox.kmpuiviews.utils.LocalNavActions
 import com.programmersbox.kmpuiviews.utils.NotificationLogo
 import com.programmersbox.kmpuiviews.utils.USE_NAV3
-import com.programmersbox.kmpuiviews.utils.composables.sharedelements.LocalSharedElementScope
 import com.programmersbox.uiviews.BuildConfig
 import com.programmersbox.uiviews.GenericInfo
 import com.programmersbox.uiviews.presentation.DebugView
@@ -68,7 +49,6 @@ fun NavigationGraph(
             genericInfo = genericInfo,
             windowSize = windowSize,
             customPreferences = customPreferences,
-            notificationLogo = notificationLogo
         )
     } else {
         Nav2(
@@ -82,88 +62,6 @@ fun NavigationGraph(
         )
     }
 }
-
-@OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalSharedTransitionApi::class)
-@Composable
-private fun Nav3(
-    backStack: SnapshotStateList<NavKey>,
-    navigationActions: NavigationActions,
-    genericInfo: GenericInfo,
-    windowSize: WindowSizeClass,
-    customPreferences: ComposeSettingsDsl,
-    notificationLogo: NotificationLogo,
-) {
-    LaunchedEffect(Unit) {
-        snapshotFlow { backStack }
-            .collect {
-                val screen = it.lastOrNull()
-                logFirebaseMessage("Navigated to: ${screen.toString()}")
-                analyticsScreen(screen.toString())
-            }
-    }
-
-    val sharedEntryInSceneNavEntryDecorator = SharedElementNavDecorator<NavKey>(
-        onPop = {},
-        { entry ->
-            with(LocalSharedElementScope.current!!) {
-                Box(
-                    Modifier.sharedElement(
-                        rememberSharedContentState(entry.contentKey),
-                        animatedVisibilityScope = LocalNavAnimatedContentScope.current,
-                    ),
-                ) {
-                    entry.Content()
-                }
-            }
-        }
-    )
-
-    NavDisplay(
-        backStack = backStack,
-        //onBack = { backStack.removeLastOrNull() },
-        sceneStrategy = rememberListDetailSceneStrategy<NavKey>(),
-        //TODO: Need to fix
-        //then remember { DialogSceneStrategy<NavKey>() },
-        onBack = {
-            if (backStack.isNotEmpty()) {
-                backStack.removeLastOrNull()
-            }
-        },
-        entryDecorators = listOf(
-            sharedEntryInSceneNavEntryDecorator,
-            rememberSaveableStateHolderNavEntryDecorator(),
-            rememberViewModelStoreNavEntryDecorator()
-        ),
-        entryProvider = entryGraph(
-            customPreferences = customPreferences,
-            notificationLogo = notificationLogo,
-            windowSize = windowSize,
-            navigationActions = navigationActions,
-            genericInfo = genericInfo
-        ),
-        transitionSpec = {
-            // Slide in from right when navigating forward
-            slideInHorizontally(initialOffsetX = { it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { -it })
-        },
-        popTransitionSpec = {
-            // Slide in from left when navigating back
-            slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { it })
-        },
-        predictivePopTransitionSpec = {
-            // Slide in from left when navigating back
-            slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                    slideOutHorizontally(targetOffsetX = { it })
-        },
-        modifier = Modifier.fillMaxSize()
-    )
-}
-
-private class SharedElementNavDecorator<T : Any>(
-    onPop: (key: Any) -> Unit,
-    decorate: @Composable ((entry: NavEntry<T>) -> Unit),
-) : NavEntryDecorator<T>(onPop, decorate)
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable

--- a/UIViews/src/main/java/com/programmersbox/uiviews/presentation/navigation/NavGraphView.kt
+++ b/UIViews/src/main/java/com/programmersbox/uiviews/presentation/navigation/NavGraphView.kt
@@ -44,8 +44,7 @@ fun NavigationGraph(
 ) {
     if (USE_NAV3) {
         Nav3(
-            backStack = (navigationActions as Navigation3Actions).backstack(),
-            navigationActions = navigationActions,
+            navigation3Actions = navigationActions as Navigation3Actions,
             genericInfo = genericInfo,
             windowSize = windowSize,
             customPreferences = customPreferences,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,7 +114,7 @@ compose-multiplatform = "1.10.0-alpha03"
 
 kotlinx-coroutines = "1.10.2"
 
-material3WindowSizeClassVersion = "1.10.0-alpha02"
+material3WindowSizeClassVersion = "1.10.0-alpha03"
 connectivity = "2.3.0"
 
 cmpLifecycle = "2.10.0-alpha03"
@@ -155,7 +155,8 @@ androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", vers
 androidx-material3-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
 
 cmp-navigation3-ui = { group = "org.jetbrains.androidx.navigation3", name = "navigation3-ui", version.ref = "cmp-nav3" }
-cmp-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version = "2.10.0-alpha03" }
+cmp-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "cmpLifecycle" }
+cmp-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version = "1.2.0-beta01" }
 
 androidx-navigationevent = { module = "androidx.navigationevent:navigationevent", version.ref = "navigationevent" }
 androidx-navigationevent-compose = { module = "androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ compose3Version = "1.3.0"
 compose3CommonVersion = "1.0.0-alpha01"
 compose3AdaptiveVersion = "1.1.0-alpha02"
 composeBomVersion = "2025.10.00"
-materialKolor = "3.0.1"
+materialKolor = "5.0.0-alpha01"
 
 googlePerformancePlugin = "2.0.1"
 
@@ -110,14 +110,14 @@ core = "1.7.0"
 
 androidx-lifecycle = "2.9.5"
 
-compose-multiplatform = "1.10.0-alpha02"
+compose-multiplatform = "1.10.0-alpha03"
 
 kotlinx-coroutines = "1.10.2"
 
 material3WindowSizeClassVersion = "1.10.0-alpha02"
 connectivity = "2.3.0"
 
-cmpLifecycle = "2.9.5"
+cmpLifecycle = "2.10.0-alpha03"
 navigationCmp = "2.9.10-alpha01"
 
 buildKonfig = "0.17.1"
@@ -129,6 +129,8 @@ navigationevent = "1.0.0-beta01"
 
 navigation3 = "1.0.0-alpha11"
 nav3Material = "1.3.0-alpha01"
+
+cmp-nav3 = "1.0.0-alpha03"
 
 [plugins]
 kotlinGradle = { id = "org.jetbrains.kotlin:kotlin.gradle.plugin", version.ref = "kotlin" }
@@ -151,6 +153,9 @@ androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecy
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 androidx-material3-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
+
+cmp-navigation3-ui = { group = "org.jetbrains.androidx.navigation3", name = "navigation3-ui", version.ref = "cmp-nav3" }
+cmp-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version = "2.10.0-alpha03" }
 
 androidx-navigationevent = { module = "androidx.navigationevent:navigationevent", version.ref = "navigationevent" }
 androidx-navigationevent-compose = { module = "androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }

--- a/kmpuiviews/build.gradle.kts
+++ b/kmpuiviews/build.gradle.kts
@@ -141,6 +141,7 @@ kotlin {
 
                 implementation(libs.cmp.navigation3.ui)
                 implementation(libs.cmp.lifecycle.viewmodel.navigation3)
+                implementation(libs.cmp.material3.adaptive)
             }
         }
 

--- a/kmpuiviews/build.gradle.kts
+++ b/kmpuiviews/build.gradle.kts
@@ -138,6 +138,9 @@ kotlin {
                 implementation(libs.xemantic.ai.tool.schema)
 
                 implementation(libs.heatmap)
+
+                implementation(libs.cmp.navigation3.ui)
+                implementation(libs.cmp.lifecycle.viewmodel.navigation3)
             }
         }
 

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
 import com.programmersbox.favoritesdatabase.DbModel
 import com.programmersbox.kmpmodels.KmpChapterModel
 import com.programmersbox.kmpmodels.KmpInfoModel
@@ -89,8 +91,25 @@ interface KmpGenericInfo {
     context(navGraph: NavGraphBuilder)
     fun settingsNavSetup(): Unit = Unit
 
+    context(navGraph: EntryProviderScope<NavKey>)
+    fun globalNav3Setup() {
+    }
+
+    context(navGraph: EntryProviderScope<NavKey>)
+    fun settingsNav3Setup() {
+    }
+
     @Composable
     fun DialogSetups() = Unit
+
+    @Composable
+    fun AccountContent() = Unit
+
+    @Composable
+    fun AccountSettings() = Unit
+
+    @Composable
+    fun ProfileIcon(): String
 }
 
 expect interface PlatformGenericInfo : KmpGenericInfo

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/HomeNav.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/HomeNav.kt
@@ -371,6 +371,7 @@ private fun HomeNavigationBar(
                     screen: Screen,
                     icon: ImageVector,
                     label: StringResource,
+                    onClick: () -> Unit = { navActions.homeScreenNavigate(screen) },
                     badge: @Composable BoxScope.() -> Unit = {},
                 ) {
                     NavigationBarItem(
@@ -378,7 +379,7 @@ private fun HomeNavigationBar(
                         label = { Text(stringResource(label)) },
                         selected = navActions.currentDestination(screen),
                         colors = colors,
-                        onClick = { navActions.homeScreenNavigate(screen) }
+                        onClick = onClick
                     )
                 }
 
@@ -407,7 +408,8 @@ private fun HomeNavigationBar(
                     screen = Screen.Settings,
                     icon = if (navActions.currentDestination(Screen.Settings)) Icons.Default.Settings else Icons.Outlined.Settings,
                     label = Res.string.settings,
-                    badge = { if (updateCheck()) Badge { Text("") } }
+                    badge = { if (updateCheck()) Badge { Text("") } },
+                    onClick = { navActions.settings() }
                 )
             }
 

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/details/DetailsUtils.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/details/DetailsUtils.kt
@@ -561,7 +561,7 @@ fun ChapterListHeader(
         overflowIndicator = { menuState ->
             FilledIconButton(
                 onClick = {
-                    if (menuState.isExpanded) {
+                    if (menuState.isShowing) {
                         menuState.dismiss()
                     } else {
                         menuState.show()

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navactions/Navigation3Actions.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navactions/Navigation3Actions.kt
@@ -1,6 +1,7 @@
 package com.programmersbox.kmpuiviews.presentation.navactions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -14,7 +15,7 @@ import net.thauvin.erik.urlencoder.UrlEncoderUtil
 
 class Navigation3Actions(private val navBackStack: TopLevelBackStack<NavKey>) : NavigationActions {
 
-    fun backstack() = navBackStack.backStack
+    val backStack by derivedStateOf { navBackStack.backStack }
 
     override fun recent() {
         navBackStack.addTopLevel(Screen.RecentScreen)
@@ -210,7 +211,7 @@ class Navigation3Actions(private val navBackStack: TopLevelBackStack<NavKey>) : 
     @Composable
     override fun currentDestination(screen: Screen): Boolean {
         //return navBackStack.lastOrNull() == screen
-        return screen == navBackStack.topLevelKey
+        return navBackStack.contains(screen)
     }
 }
 
@@ -227,6 +228,8 @@ class TopLevelBackStack<T : Any>(startKey: T) {
 
     // Expose the back stack so it can be rendered by the NavDisplay
     val backStack = mutableStateListOf(startKey)
+
+    fun contains(key: T) = topLevelStacks[topLevelKey]?.contains(key) == true || topLevelKey == key
 
     private fun updateBackStack() =
         backStack.apply {

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3Graph.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3Graph.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.scene.DialogSceneStrategy
 import com.programmersbox.kmpuiviews.BuildType
 import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.presentation.Screen
@@ -252,7 +253,7 @@ private inline fun <reified T : NavKey> EntryProviderScope<NavKey>.dialogEntry(
     noinline content: @Composable (T) -> Unit,
 ) = entry<T>(
     //TODO: Need to fix
-    //metadata = DialogSceneStrategy.dialog()
+    metadata = DialogSceneStrategy.dialog()
 ) { content(it) }
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3Graph.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3Graph.kt
@@ -1,0 +1,272 @@
+package com.programmersbox.kmpuiviews.presentation.navigation
+
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import com.programmersbox.kmpuiviews.BuildType
+import com.programmersbox.kmpuiviews.KmpGenericInfo
+import com.programmersbox.kmpuiviews.presentation.Screen
+import com.programmersbox.kmpuiviews.presentation.about.AboutLibrariesScreen
+import com.programmersbox.kmpuiviews.presentation.all.AllScreen
+import com.programmersbox.kmpuiviews.presentation.details.DetailsScreen
+import com.programmersbox.kmpuiviews.presentation.favorite.FavoriteScreen
+import com.programmersbox.kmpuiviews.presentation.globalsearch.GlobalSearchScreen
+import com.programmersbox.kmpuiviews.presentation.history.HistoryUi
+import com.programmersbox.kmpuiviews.presentation.navactions.NavigationActions
+import com.programmersbox.kmpuiviews.presentation.notifications.NotificationScreen
+import com.programmersbox.kmpuiviews.presentation.onboarding.OnboardingScreen
+import com.programmersbox.kmpuiviews.presentation.recent.RecentView
+import com.programmersbox.kmpuiviews.presentation.recommendations.RecommendationScreen
+import com.programmersbox.kmpuiviews.presentation.settings.SettingScreen
+import com.programmersbox.kmpuiviews.presentation.settings.accountinfo.AccountInfoScreen
+import com.programmersbox.kmpuiviews.presentation.settings.downloadstate.DownloadStateScreen
+import com.programmersbox.kmpuiviews.presentation.settings.exceptions.ExceptionsScreen
+import com.programmersbox.kmpuiviews.presentation.settings.extensions.ExtensionList
+import com.programmersbox.kmpuiviews.presentation.settings.general.DetailsSettingsScreen
+import com.programmersbox.kmpuiviews.presentation.settings.general.GeneralSettings
+import com.programmersbox.kmpuiviews.presentation.settings.general.ThemeSettingsScreen
+import com.programmersbox.kmpuiviews.presentation.settings.incognito.IncognitoScreen
+import com.programmersbox.kmpuiviews.presentation.settings.lists.OtakuCustomListScreenStandAlone
+import com.programmersbox.kmpuiviews.presentation.settings.lists.OtakuListView
+import com.programmersbox.kmpuiviews.presentation.settings.lists.deletefromlist.DeleteFromListScreen
+import com.programmersbox.kmpuiviews.presentation.settings.lists.imports.ImportFullListScreen
+import com.programmersbox.kmpuiviews.presentation.settings.lists.imports.ImportListScreen
+import com.programmersbox.kmpuiviews.presentation.settings.moreinfo.MoreInfoScreen
+import com.programmersbox.kmpuiviews.presentation.settings.moresettings.MoreSettingsScreen
+import com.programmersbox.kmpuiviews.presentation.settings.notifications.NotificationSettings
+import com.programmersbox.kmpuiviews.presentation.settings.player.PlaySettings
+import com.programmersbox.kmpuiviews.presentation.settings.prerelease.PrereleaseScreen
+import com.programmersbox.kmpuiviews.presentation.settings.qrcode.ScanQrCode
+import com.programmersbox.kmpuiviews.presentation.settings.security.SecurityScreen
+import com.programmersbox.kmpuiviews.presentation.settings.sourceorder.SourceOrderScreen
+import com.programmersbox.kmpuiviews.presentation.settings.utils.ColorHelperScreen
+import com.programmersbox.kmpuiviews.presentation.settings.workerinfo.WorkerInfoScreen
+import com.programmersbox.kmpuiviews.presentation.urlopener.UrlOpenerScreen
+import com.programmersbox.kmpuiviews.presentation.webview.WebViewScreen
+import com.programmersbox.kmpuiviews.utils.AppConfig
+import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
+import com.programmersbox.kmpuiviews.utils.LocalNavActions
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class, ExperimentalFoundationApi::class)
+fun entryGraph(
+    customPreferences: ComposeSettingsDsl,
+    windowSize: WindowSizeClass,
+    genericInfo: KmpGenericInfo,
+    navigationActions: NavigationActions,
+) = entryProvider<NavKey> {
+    entry<Screen.RecentScreen> { RecentView() }
+    entry<Screen.DetailsScreen.Details> {
+        DetailsScreen(
+            windowSize = windowSize,
+            details = koinViewModel { parametersOf(it) }
+        )
+    }
+
+    dialogEntry<Screen.ScanQrCodeScreen> { ScanQrCode() }
+
+    entry<Screen.OnboardingScreen> {
+        OnboardingScreen(
+            navController = LocalNavActions.current,
+            customPreferences = customPreferences,
+            accountContent = genericInfo::AccountContent
+        )
+    }
+
+    entry<Screen.WebViewScreen> {
+        WebViewScreen(
+            url = it.url
+        )
+    }
+
+    entry<Screen.IncognitoScreen> {
+        IncognitoScreen()
+    }
+
+    entry<Screen.AllScreen> {
+        AllScreen(
+            isHorizontal = windowSize.widthSizeClass == WindowWidthSizeClass.Expanded
+        )
+    }
+
+    settingsEntryGraph(
+        customPreferences = customPreferences,
+        windowSize = windowSize,
+        genericInfo = genericInfo,
+        navigationActions = navigationActions,
+    )
+
+    genericInfo.globalNav3Setup()
+}
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class, ExperimentalMaterial3AdaptiveApi::class)
+private fun EntryProviderScope<NavKey>.settingsEntryGraph(
+    customPreferences: ComposeSettingsDsl,
+    windowSize: WindowSizeClass,
+    genericInfo: KmpGenericInfo,
+    navigationActions: NavigationActions,
+) {
+    entry<Screen.Settings>(
+        //metadata = ListDetailSceneStrategy.listPane()
+    ) {
+        SettingScreen(
+            composeSettingsDsl = customPreferences,
+            navigationActions = navigationActions,
+            accountSettings = {
+                val appConfig: AppConfig = koinInject()
+                if (appConfig.buildType == BuildType.Full) {
+                    genericInfo.AccountSettings()
+                }
+            }
+        )
+    }
+
+    twoPaneEntry<Screen.WorkerInfoScreen> { WorkerInfoScreen() }
+
+    twoPaneEntry<Screen.OrderScreen> {
+        SourceOrderScreen()
+    }
+
+    twoPaneEntry<Screen.NotificationsSettings> {
+        NotificationSettings()
+    }
+
+    twoPaneEntry<Screen.GeneralSettings> {
+        GeneralSettings(customPreferences.generalSettings)
+    }
+
+    twoPaneEntry<Screen.MoreInfoSettings> {
+        MoreInfoScreen(
+            usedLibraryClick = navigationActions::about,
+            onViewAccountInfoClick = navigationActions::accountInfo
+        )
+    }
+
+    entry<Screen.PrereleaseScreen> { PrereleaseScreen() }
+
+    twoPaneEntry<Screen.OtherSettings> {
+        PlaySettings(customPreferences.playerSettings)
+    }
+
+    twoPaneEntry<Screen.MoreSettings> {
+        MoreSettingsScreen()
+    }
+
+    twoPaneEntry<Screen.HistoryScreen> {
+        HistoryUi()
+    }
+
+    entry<Screen.FavoriteScreen> {
+        FavoriteScreen(
+            isHorizontal = windowSize.widthSizeClass == WindowWidthSizeClass.Expanded
+        )
+    }
+
+    twoPaneEntry<Screen.AboutScreen> {
+        AboutLibrariesScreen()
+    }
+
+    entry<Screen.GlobalSearchScreen> {
+        GlobalSearchScreen(
+            isHorizontal = windowSize.widthSizeClass == WindowWidthSizeClass.Expanded,
+            screen = it
+        )
+    }
+
+    entry<Screen.CustomListScreen>(
+        //metadata = ListDetailSceneStrategy.listPane()
+    ) {
+        OtakuListView()
+    }
+
+    twoPaneEntry<Screen.CustomListScreen.CustomListItem> {
+        OtakuCustomListScreenStandAlone(it)
+    }
+
+    dialogEntry<Screen.CustomListScreen.DeleteFromList> {
+        DeleteFromListScreen(
+            deleteFromList = it
+        )
+    }
+
+    entry<Screen.ImportListScreen> {
+        ImportListScreen()
+    }
+
+    entry<Screen.ImportFullListScreen> {
+        ImportFullListScreen()
+    }
+
+    twoPaneEntry<Screen.NotificationScreen> {
+        NotificationScreen()
+    }
+
+    entry<Screen.ExtensionListScreen> {
+        ExtensionList()
+    }
+
+    entry<Screen.GeminiScreen> {
+        RecommendationScreen()
+    }
+
+    twoPaneEntry<Screen.AccountInfo> {
+        AccountInfoScreen(
+            profileUrl = genericInfo.ProfileIcon(),
+        )
+    }
+
+    //additionalSettings()
+
+    entry<Screen.DownloadInstallScreen> {
+        DownloadStateScreen()
+    }
+
+    entry<Screen.UrlOpener> { UrlOpenerScreen() }
+    entry<Screen.ColorHelper> { ColorHelperScreen() }
+    entry<Screen.ThemeSettings> { ThemeSettingsScreen() }
+    entry<Screen.DetailsSettings> { DetailsSettingsScreen() }
+    entry<Screen.SecuritySettings> { SecurityScreen() }
+    entry<Screen.ExceptionScreen> { ExceptionsScreen() }
+
+    genericInfo.settingsNav3Setup()
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private inline fun <reified T : NavKey> EntryProviderScope<NavKey>.twoPaneEntry(
+    noinline content: @Composable (T) -> Unit,
+) = entry<T>(
+    //metadata = ListDetailSceneStrategy.extraPane()
+) { content(it) }
+
+private inline fun <reified T : NavKey> EntryProviderScope<NavKey>.dialogEntry(
+    noinline content: @Composable (T) -> Unit,
+) = entry<T>(
+    //TODO: Need to fix
+    //metadata = DialogSceneStrategy.dialog()
+) { content(it) }
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private inline fun <reified T : NavKey> EntryProviderScope<NavKey>.detailEntry(
+    noinline content: @Composable (T) -> Unit,
+) = entry<T>(
+    //metadata = ListDetailSceneStrategy.detailPane()
+) { content(it) }
+
+/*
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private inline fun <reified T : Any> EntryProviderBuilder<*>.animatedEntry(
+    metadata: Map<String, Any> = emptyMap(),
+    noinline content: @Composable (T) -> Unit,
+) = entry<T>(
+    metadata = ListDetailSceneStrategy.detailPane()
+) { CompositionLocalProvider(LocalNavigationAnimatedScope provides this) { content(it) } }*/

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3View.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3View.kt
@@ -1,0 +1,108 @@
+package com.programmersbox.kmpuiviews.presentation.navigation
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavEntryDecorator
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import androidx.navigation3.ui.NavDisplay
+import com.programmersbox.kmpuiviews.KmpGenericInfo
+import com.programmersbox.kmpuiviews.analyticsScreen
+import com.programmersbox.kmpuiviews.logFirebaseMessage
+import com.programmersbox.kmpuiviews.presentation.navactions.NavigationActions
+import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
+import com.programmersbox.kmpuiviews.utils.composables.sharedelements.LocalSharedElementScope
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalSharedTransitionApi::class)
+@Composable
+fun Nav3(
+    backStack: SnapshotStateList<NavKey>,
+    navigationActions: NavigationActions,
+    genericInfo: KmpGenericInfo,
+    windowSize: WindowSizeClass,
+    customPreferences: ComposeSettingsDsl,
+) {
+    LaunchedEffect(Unit) {
+        snapshotFlow { backStack }
+            .collect {
+                val screen = it.lastOrNull()
+                logFirebaseMessage("Navigated to: ${screen.toString()}")
+                analyticsScreen(screen.toString())
+            }
+    }
+
+    val sharedEntryInSceneNavEntryDecorator = SharedElementNavDecorator<NavKey>(
+        onPop = {},
+        { entry ->
+            with(LocalSharedElementScope.current!!) {
+                Box(
+                    Modifier.sharedElement(
+                        rememberSharedContentState(entry.contentKey),
+                        animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+                    ),
+                ) {
+                    entry.Content()
+                }
+            }
+        }
+    )
+
+    NavDisplay(
+        backStack = backStack,
+        //onBack = { backStack.removeLastOrNull() },
+        //sceneStrategy = rememberListDetailSceneStrategy<NavKey>(),
+        //TODO: Need to fix
+        //then remember { DialogSceneStrategy<NavKey>() },
+        onBack = {
+            if (backStack.isNotEmpty()) {
+                backStack.removeLastOrNull()
+            }
+        },
+        entryDecorators = listOf(
+            sharedEntryInSceneNavEntryDecorator,
+            rememberSaveableStateHolderNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator()
+        ),
+        entryProvider = entryGraph(
+            customPreferences = customPreferences,
+            windowSize = windowSize,
+            navigationActions = navigationActions,
+            genericInfo = genericInfo
+        ),
+        transitionSpec = {
+            // Slide in from right when navigating forward
+            slideInHorizontally(initialOffsetX = { it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { -it })
+        },
+        popTransitionSpec = {
+            // Slide in from left when navigating back
+            slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { it })
+        },
+        predictivePopTransitionSpec = {
+            // Slide in from left when navigating back
+            slideInHorizontally(initialOffsetX = { -it }) togetherWith
+                    slideOutHorizontally(targetOffsetX = { it })
+        },
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+private class SharedElementNavDecorator<T : Any>(
+    onPop: (key: Any) -> Unit,
+    decorate: @Composable ((entry: NavEntry<T>) -> Unit),
+) : NavEntryDecorator<T>(onPop, decorate)

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3View.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/navigation/Nav3View.kt
@@ -10,32 +10,33 @@ import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.navigation3.ui.NavDisplay
 import com.programmersbox.kmpuiviews.KmpGenericInfo
 import com.programmersbox.kmpuiviews.analyticsScreen
 import com.programmersbox.kmpuiviews.logFirebaseMessage
-import com.programmersbox.kmpuiviews.presentation.navactions.NavigationActions
+import com.programmersbox.kmpuiviews.presentation.navactions.Navigation3Actions
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import com.programmersbox.kmpuiviews.utils.composables.sharedelements.LocalSharedElementScope
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun Nav3(
-    backStack: SnapshotStateList<NavKey>,
-    navigationActions: NavigationActions,
+    navigation3Actions: Navigation3Actions,
     genericInfo: KmpGenericInfo,
     windowSize: WindowSizeClass,
     customPreferences: ComposeSettingsDsl,
 ) {
+    val backStack = navigation3Actions.backStack
     LaunchedEffect(Unit) {
         snapshotFlow { backStack }
             .collect {
@@ -47,12 +48,17 @@ fun Nav3(
 
     val sharedEntryInSceneNavEntryDecorator = SharedElementNavDecorator<NavKey>(
         onPop = {},
-        { entry ->
+        decorate = { entry ->
+            val animatedScope = runCatching { LocalNavAnimatedContentScope.current }.getOrNull()
+            if (animatedScope == null) {
+                entry.Content()
+                return@SharedElementNavDecorator
+            }
             with(LocalSharedElementScope.current!!) {
                 Box(
                     Modifier.sharedElement(
                         rememberSharedContentState(entry.contentKey),
-                        animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+                        animatedVisibilityScope = animatedScope,
                     ),
                 ) {
                     entry.Content()
@@ -67,11 +73,8 @@ fun Nav3(
         //sceneStrategy = rememberListDetailSceneStrategy<NavKey>(),
         //TODO: Need to fix
         //then remember { DialogSceneStrategy<NavKey>() },
-        onBack = {
-            if (backStack.isNotEmpty()) {
-                backStack.removeLastOrNull()
-            }
-        },
+        sceneStrategy = remember { DialogSceneStrategy() },
+        onBack = { navigation3Actions.popBackStack() },
         entryDecorators = listOf(
             sharedEntryInSceneNavEntryDecorator,
             rememberSaveableStateHolderNavEntryDecorator(),
@@ -80,7 +83,7 @@ fun Nav3(
         entryProvider = entryGraph(
             customPreferences = customPreferences,
             windowSize = windowSize,
-            navigationActions = navigationActions,
+            navigationActions = navigation3Actions,
             genericInfo = genericInfo
         ),
         transitionSpec = {

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/Utils.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/Utils.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.flow
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.module.dsl.binds
 
-const val USE_NAV3 = false
+const val USE_NAV3 = true
 
 fun SourceRepository.loadItem(
     source: String,


### PR DESCRIPTION
This commit enables the Navigation 3 (`Nav3`) implementation by default and migrates the core navigation logic, including the graph and display components, into the `kmpuiviews` common module. This centralizes navigation and prepares for a more unified cross-platform experience.

- **Feature Flag**:
    - In `kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/Utils.kt`, the `USE_NAV3` constant has been switched to `true`, making Navigation 3 the default navigation system.

- **Dependency Updates (`gradle/libs.versions.toml` & `kmpuiviews/build.gradle.kts`):**
    - `compose-multiplatform`: `1.10.0-alpha02` -> `1.10.0-alpha03`
    - `cmpLifecycle`: `2.9.5` -> `2.10.0-alpha03`
    - `materialKolor`: `3.0.1` -> `5.0.0-alpha01`
    - Added new KMP-compatible Navigation 3 libraries:
        - `cmp-nav3`: `1.0.0-alpha03`
        - `cmp-navigation3-ui` - `cmp-lifecycle-viewmodel-navigation3`

- **KMP Navigation Migration**:
    - **`kmpuiviews/presentation/navigation/Nav3View.kt`** & **`Nav3Graph.kt`**: New files created to house the core `NavDisplay` composable and the `entryProvider` graph, previously located in the `UIViews` module.
    - **`UIViews/presentation/navigation/NavGraphView.kt`**: The Android-specific `Nav3` composable has been removed and replaced with a call to the new shared `Nav3` composable from `kmpuiviews`.

- **Generic Info & Platform Abstraction**:
    - **`kmpuiviews/GenericInfo.kt`**: The `KmpGenericInfo` interface is expanded with new `@Composable` functions (`AccountContent`, `AccountSettings`, `ProfileIcon`) and Nav3-specific setup functions (`globalNav3Setup`, `settingsNav3Setup`).
    - **`UIViews/GenericInfo.kt`**: The Android implementation of `GenericInfo` now provides concrete implementations for the new account-related composable functions, delegating to existing UI components and `koinViewModel`.

- **Minor Fix**:
    - **`kmpuiviews/presentation/details/DetailsUtils.kt`**: Updated `menuState.isExpanded` to `menuState.isShowing` to align with a library API change.