### PR TITLE
feat: transition extension loading from APK to JAR and add KMP servic…

### DIFF
--- a/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/ExtensionLoader.kt
+++ b/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/ExtensionLoader.kt
@@ -20,41 +20,45 @@ class ExtensionLoader<T, R>(
 ) {
     fun loadExtensions(mapped: suspend (T, ApplicationInfo, PackageInfo) -> R = mapping): List<R> =
         runBlocking {
-            findExtensionApks()
+            findExtensionJars()
                 .map { async { loadExtension(it, mapped) } }
                 .flatMap { it.await() }
         }
 
     suspend fun loadExtensionsBlocking(mapped: suspend (T, ApplicationInfo, PackageInfo) -> R = mapping): List<R> =
         coroutineScope {
-            findExtensionApks()
+            findExtensionJars()
                 .map { async { loadExtension(it, mapped) } }
                 .awaitAll()
                 .flatten()
         }
 
-    private fun findExtensionApks(): List<File> {
+    private fun findExtensionJars(): List<File> {
         if (!extensionsDir.exists() || !extensionsDir.isDirectory) return emptyList()
         return extensionsDir
-            .listFiles { f -> f.isFile && f.extension.equals("apk", ignoreCase = true) }
+            .listFiles { f -> f.isFile && f.extension.equals("jar", ignoreCase = true) }
             ?.toList()
             ?: emptyList()
     }
 
-    private suspend fun loadExtension(apkFile: File, mapped: suspend (T, ApplicationInfo, PackageInfo) -> R): List<R> {
+    private suspend fun loadExtension(jarFile: File, mapped: suspend (T, ApplicationInfo, PackageInfo) -> R): List<R> {
         return runCatching {
-            val manifest = ApkManifestParser.parse(apkFile)
+            val manifest = JarManifestParser.parse(jarFile)
 
-            if (!manifest.features.contains(extensionFeature)) return emptyList()
+            println("$jarFile: $manifest")
 
-            //TODO: Need to only read jar files
+            println(manifest.features)
+            println(manifest.metaData)
+            println("Extension Feature: $extensionFeature")
 
-            val jar = DexConverter.convert(apkFile, cacheDir) ?: return emptyList()
+            if (!manifest.features.contains(extensionFeature) && !manifest.metaData.contains(extensionFeature)) return emptyList()
 
             val classLoader = URLClassLoader(
-                arrayOf(jar.toURI().toURL()),
+                arrayOf(jarFile.toURI().toURL()),
                 this::class.java.classLoader,
             )
+
+            println("Classloader: $classLoader")
 
             val packageInfo = PackageInfo().apply {
                 packageName = manifest.packageName
@@ -62,17 +66,24 @@ class ExtensionLoader<T, R>(
                 reqFeatures = manifest.features.map { FeatureInfo().apply { name = it } }.toTypedArray()
             }
 
+            println("PackageInfo: $packageInfo")
+
             val metaBundle = Bundle().apply {
                 manifest.metaData.forEach { (k, v) -> putString(k, v) }
             }
 
+            println("MetaBundle: $metaBundle")
+
             val appInfo = ApplicationInfo().apply {
                 packageName = manifest.packageName
-                sourceDir = apkFile.absolutePath
+                sourceDir = jarFile.absolutePath
                 metaData = metaBundle
             }
 
+            println("AppInfo: $appInfo")
+
             val classNames = metaBundle.getString(metadataClass)
+                .also { println("Metadata Class: $metadataClass") }
                 .orEmpty()
                 .split(";")
                 .map { cls ->
@@ -81,21 +92,32 @@ class ExtensionLoader<T, R>(
                 }
                 .filter { it.isNotBlank() }
 
+            println("ClassNames: $classNames")
+
             classNames.mapNotNull { className ->
                 runCatching {
+                    val loadedClass = classLoader.loadClass(className)
+
+                    // 1. Try to get the singleton INSTANCE if it's a Kotlin `object`
+                    val instance = try {
+                        loadedClass.getDeclaredField("INSTANCE").get(null)
+                    } catch (e: NoSuchFieldException) {
+                        // 2. If there is no INSTANCE field, it's a normal `class`. Instantiate it.
+                        loadedClass.getDeclaredConstructor().newInstance()
+                    }
+
                     @Suppress("UNCHECKED_CAST")
-                    Class.forName(className, false, classLoader)
-                        .getDeclaredConstructor()
-                        .newInstance() as? T
+                    instance as? T
                 }
                     .onFailure { e ->
+                        e.printStackTrace()
                         val cause = e.cause?.let { " caused by: ${it.message}" } ?: ""
                         println("ExtensionLoader: failed to load $className: ${e.message}$cause")
                     }
                     .getOrNull()
             }.map { mapped(it, appInfo, packageInfo) }
         }
-            .onFailure { println("ExtensionLoader: failed to load ${apkFile.name}: ${it.message}") }
+            .onFailure { println("ExtensionLoader: failed to load ${jarFile.name}: ${it.message}") }
             .getOrElse { emptyList() }
     }
 }

--- a/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/JarManifestParser.kt
+++ b/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/JarManifestParser.kt
@@ -1,0 +1,46 @@
+package com.programmersbox.kmpextensionloader
+
+import java.io.File
+import java.util.jar.JarFile
+
+data class JarManifest(
+    val packageName: String,
+    val versionName: String?,
+    val features: Set<String>,
+    val metaData: Map<String, String>,
+)
+
+object JarManifestParser {
+    fun parse(jarFile: File): JarManifest {
+        JarFile(jarFile).use { jar ->
+            val attrs = jar.manifest?.mainAttributes
+                ?: return JarManifest("", null, emptySet(), emptyMap())
+
+            val metaData = mutableMapOf<String, String>()
+            for (key in attrs.keys) {
+                val keyStr = key.toString()
+                val value = attrs.getValue(keyStr) ?: continue
+                // Store under both the original hyphenated key and the dot-converted key
+                // so Bundle lookups using "programmersbox.otaku.class" find the value
+                metaData[keyStr] = value
+                metaData[keyStr.replace('-', '.')] = value
+            }
+
+            val packageName = attrs.getValue("programmersbox-otaku-package") ?: ""
+            val versionName = attrs.getValue("programmersbox-otaku-version")
+                ?: attrs.getValue("Implementation-Version")
+
+            val features = buildSet<String> {
+                // Single feature per JAR: "programmersbox.otaku.extension.manga" etc.
+                attrs.getValue("programmersbox-otaku-extension")?.let { add(it) }
+            }
+
+            return JarManifest(
+                packageName = packageName,
+                versionName = versionName,
+                features = features,
+                metaData = metaData,
+            )
+        }
+    }
+}

--- a/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/SourceLoader.kt
+++ b/sharedutils/kmpextensionloader/src/jvmMain/kotlin/com/programmersbox/kmpextensionloader/SourceLoader.kt
@@ -1,9 +1,11 @@
 package com.programmersbox.kmpextensionloader
 
 import android.app.Application
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageInfo
 import ca.gosyer.appdirs.AppDirs
+import com.programmersbox.kmpmodels.KmpApiService
+import com.programmersbox.kmpmodels.KmpApiServicesCatalog
+import com.programmersbox.kmpmodels.KmpExternalApiServicesCatalog
+import com.programmersbox.kmpmodels.KmpExternalCustomApiServicesCatalog
 import com.programmersbox.kmpmodels.KmpSourceInformation
 import com.programmersbox.kmpmodels.SourceRepository
 import com.programmersbox.models.ApiService
@@ -13,8 +15,8 @@ import com.programmersbox.models.ExternalCustomApiServicesCatalog
 import com.programmersbox.models.SourceInformation
 import java.io.File
 
-private const val METADATA_NAME = "programmersbox.otaku.name"
-private const val METADATA_CLASS = "programmersbox.otaku.class"
+private const val METADATA_NAME = "programmersbox-otaku-name"
+private const val METADATA_CLASS = "programmersbox-otaku-class"
 private const val EXTENSION_FEATURE = "programmersbox.otaku.extension"
 
 actual class SourceLoader(
@@ -32,44 +34,91 @@ actual class SourceLoader(
         extensionFeature = "$EXTENSION_FEATURE.$sourceType",
         metadataClass = METADATA_CLASS,
         mapping = suspend { t, appInfo, packageInfo ->
-        val metaName = appInfo.metaData?.getString(METADATA_NAME) ?: "Unknown"
-        val pkgName = packageInfo.packageName
-        val pluginApp = Application(pkgName, dataDir, appInfo.sourceDir)
-        val mapper = JvmModelMapper(pluginApp)
+            println("Mapping $t")
+            val metaName = appInfo.metaData?.getString(METADATA_NAME) ?: "Unknown"
+            val pkgName = packageInfo.packageName
+            val pluginApp = Application(pkgName, dataDir, appInfo.sourceDir)
+            val mapper = JvmModelMapper(pluginApp)
 
-        when (t) {
-            is ApiService -> listOf(
-                SourceInformation(
-                    apiService = t,
-                    name = metaName,
-                    icon = null,
-                    packageName = pkgName,
+            when (t) {
+                is ApiService -> listOf(
+                    SourceInformation(
+                        apiService = t,
+                        name = metaName,
+                        icon = null,
+                        packageName = pkgName,
+                    )
                 )
-            )
 
-            is ExternalCustomApiServicesCatalog -> {
-                t.initialize(pluginApp)
-                t.getSources().map { it.copy(catalog = t) }
-            }
+                is ExternalCustomApiServicesCatalog -> {
+                    t.initialize(pluginApp)
+                    t.getSources().map { it.copy(catalog = t) }
+                }
 
-            is ExternalApiServicesCatalog -> {
-                t.initialize(pluginApp)
-                t.getSources().map { it.copy(catalog = t) }
-            }
+                is ExternalApiServicesCatalog -> {
+                    t.initialize(pluginApp)
+                    t.getSources().map { it.copy(catalog = t) }
+                }
 
-            is ApiServicesCatalog -> t.createSources().map { service ->
-                SourceInformation(
-                    apiService = service,
-                    name = metaName,
-                    icon = null,
-                    packageName = pkgName,
-                    catalog = t,
+                is ApiServicesCatalog -> t.createSources().map { service ->
+                    SourceInformation(
+                        apiService = service,
+                        name = metaName,
+                        icon = null,
+                        packageName = pkgName,
+                        catalog = t,
+                    )
+                }
+
+                is KmpApiService -> listOf(
+                    KmpSourceInformation(
+                        apiService = t,
+                        name = metaName,
+                        icon = null,
+                        packageName = pkgName,
+                    )
                 )
-            }
 
-            else -> emptyList()
-        }.map { mapper.mapSourceInformation(it) }
-    })
+                is KmpExternalCustomApiServicesCatalog -> {
+                    t.initialize()
+                    t.createSources().map { service ->
+                        KmpSourceInformation(
+                            apiService = service,
+                            name = metaName,
+                            icon = null,
+                            packageName = pkgName,
+                            catalog = t,
+                        )
+                    }
+                }
+
+                is KmpExternalApiServicesCatalog -> {
+                    t.initialize()
+                    t.getSources().map { it.copy(catalog = t) }
+                }
+
+                is KmpApiServicesCatalog -> t.createSources().map { service ->
+                    KmpSourceInformation(
+                        apiService = service,
+                        name = metaName,
+                        icon = null,
+                        packageName = pkgName,
+                        catalog = t,
+                    )
+                }
+
+                else -> emptyList()
+            }
+                .mapNotNull {
+                    when (it) {
+                        is KmpSourceInformation -> it
+                        is SourceInformation -> mapper.mapSourceInformation(it)
+                        else -> null
+                    }
+                }
+                .also { println(it) }
+        }
+    )
 
     actual fun load() {
         sourceRepository.setSources(


### PR DESCRIPTION
…e support

This commit refactors the JVM extension loading mechanism to support JAR files instead of APKs and expands the `SourceLoader` to handle various KMP-specific service and catalog types.

- **Extension Loading Refactor**:
    - **`JarManifestParser.kt`**: Introduced a new parser to extract metadata (package name, version, features, and custom meta-data) from JAR manifests. It automatically maps hyphenated manifest keys to dot-notation for compatibility.
    - **`ExtensionLoader.kt`**:
        - Replaced `findExtensionApks` with `findExtensionJars`.
        - Removed `DexConverter` logic as it is no longer required for JVM JAR loading. - Improved class instantiation to support both Kotlin `object` singletons (via the `INSTANCE` field) and standard classes. - Added verbose logging for manifest parsing, class loading, and instantiation.

- **Source Loader Updates**:
    - **`SourceLoader.kt`**: - Updated metadata keys to use hyphenated versions (e.g., `programmersbox-otaku-name`, `programmersbox-otaku-class`) to align with standard JAR manifest attributes. - Significantly expanded the mapping logic to support new KMP interfaces: `KmpApiService`, `KmpApiServicesCatalog`, `KmpExternalApiServicesCatalog`, and `KmpExternalCustomApiServicesCatalog`. - Refactored the return type handling to support both legacy `SourceInformation` (mapped via `JvmModelMapper`) and the new `KmpSourceInformation` type.