### PR TITLE
refactor: consolidate Desktop initialization and improve service reso…

### DIFF
--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/repository/SetupRepository.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/repository/SetupRepository.kt
@@ -9,6 +9,8 @@ import com.programmersbox.kmpuiviews.domain.AppUpdateCheck
 import com.programmersbox.kmpuiviews.utils.dispatchIo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
@@ -37,9 +39,12 @@ class SetupRepository(
             }
             .launchIn(scope)
 
-        dataStoreHandling
-            .currentService
-            .asFlow()
+        combine(
+            dataStoreHandling
+                .currentService
+                .asFlow(),
+            sourceRepository.sources,
+        ) { service, _ -> service }
             .mapNotNull {
                 if (it == null) {
                     sourceRepository
@@ -50,6 +55,7 @@ class SetupRepository(
                     sourceRepository.toSourceByApiServiceName(it)
                 }
             }
+            .distinctUntilChanged()
             .onEach { currentSourceRepository.emit(it.apiService) }
             .launchIn(scope)
 

--- a/kmpuiviews/src/jvmMain/kotlin/com/programmersbox/kmpuiviews/DesktopUi.kt
+++ b/kmpuiviews/src/jvmMain/kotlin/com/programmersbox/kmpuiviews/DesktopUi.kt
@@ -144,6 +144,7 @@ fun ApplicationScope.BaseDesktopUi(
             val setupRepository = koinInject<SetupRepository>()
             val extensionWatcher = koinInject<ExtensionWatcher>()
             LaunchedEffect(Unit) {
+                setupRepository.setup(this)
                 val exampleService = ExampleService.getSourceInformation()
                 extensionWatcher
                     .observeExtensionsDir()
@@ -152,10 +153,6 @@ fun ApplicationScope.BaseDesktopUi(
                         sourceRepository.addSource(exampleService)
                     }
                     .launchIn(this)
-            }
-
-            LaunchedEffect(Unit) {
-                setupRepository.setup(this)
             }
 
             val windowState = rememberWindowState()


### PR DESCRIPTION
…lution

- **Desktop UI**:
    - Consolidated multiple `LaunchedEffect(Unit)` blocks in `DesktopUi.kt` into a single effect to streamline initialization logic.
    - Moved the `setupRepository.setup()` call to run within the same coroutine scope as the `ExtensionWatcher` observation.

- **Setup Repository**:
    - Refactored service resolution logic in `SetupRepository.kt` to use `combine`, synchronizing the `currentService` flow with `sourceRepository.sources`. This ensures the current service is correctly re-evaluated whenever the list of available sources changes.
    - Added `distinctUntilChanged()` to the flow to prevent redundant emissions and unnecessary state updates when the resolved source has not changed.