### PR TITLE
refactor(downloads): optimize media handling and improve UI state man…

### DIFF
--- a/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadedMediaHandler.android.kt
+++ b/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadedMediaHandler.android.kt
@@ -8,24 +8,56 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.os.Handler
+import android.os.Looper
 import android.provider.MediaStore
 import androidx.core.net.toUri
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.io.File
 
 actual class DownloadedMediaHandler(
     private val context: Context,
 ) {
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // ContentObserver fires once per MediaStore row change; coalesce bursts into one query
+    private val refresh = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    private val folder = Environment
+        .getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        .toString() + "/MangaWorld/"
+
+    @OptIn(FlowPreview::class)
     actual fun init(folderLocation: String) {
-        //loadChapters(folderLocation)
-        loadChapters(
-            Environment
-                .getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                .toString() + "/MangaWorld/"
-        )
+        scope.launch { chapters.update { getMangaFolders(context, folder) } }
+
+        refresh
+            .debounce(300)
+            .onEach { chapters.update { getMangaFolders(context, folder) } }
+            .launchIn(scope)
+
+        if (contentObserver == null) {
+            contentObserver = context.contentResolver.registerObserver(externalContentUri) {
+                refresh.tryEmit(Unit)
+            }
+        }
     }
 
     actual fun listenToUpdates(): Flow<List<DownloadedChapters>> = chapters.asStateFlow()
@@ -48,13 +80,14 @@ actual class DownloadedMediaHandler(
 
     actual fun clear() {
         unregister()
+        scope.cancel()
     }
 
     private fun ContentResolver.registerObserver(
         uri: Uri,
         observer: (selfChange: Boolean) -> Unit,
     ): ContentObserver {
-        val contentObserver = object : ContentObserver(Handler()) {
+        val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
             override fun onChange(selfChange: Boolean) {
                 observer(selfChange)
             }
@@ -67,24 +100,12 @@ actual class DownloadedMediaHandler(
 
     fun unregister() {
         contentObserver?.let { context.contentResolver.unregisterContentObserver(it) }
+        contentObserver = null
     }
 
     val chapters = MutableStateFlow<List<DownloadedChapters>>(emptyList())
 
-    fun loadChapters(folderLocation: String) {
-        val imageList = getMangaFolders(context, folderLocation)
-        chapters.tryEmit(imageList)
-
-        if (contentObserver == null) {
-            contentObserver = context.contentResolver.registerObserver(externalContentUri) {
-                val imageList = getMangaFolders(context, folderLocation)
-                chapters.tryEmit(imageList)
-            }
-        }
-    }
-
     private val externalContentUri: Uri = MediaStore.Files.getContentUri("external")
-
 
     @SuppressLint("InlinedApi")
     private val projections = arrayOf(

--- a/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/MangaDownloadManager.android.kt
+++ b/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/MangaDownloadManager.android.kt
@@ -22,7 +22,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -187,30 +189,27 @@ actual class MangaDownloadManager(
             _dirTick.onStart { emit(Unit) }
         ) { downloads, _ ->
             val activeUrls = downloads.mapTo(mutableSetOf()) { it.chapterUrl }
+            // One entry per chapter directory, not per image file
             val completedFromDisk = rootDir
                 .listFiles()
                 ?.flatMap { titleDir ->
                     titleDir
                         .listFiles()
                         ?.filter { it.isDirectory && it.listFiles()?.isNotEmpty() == true }
-                        ?.flatMap { chapterDir ->
-                            chapterDir
-                                .listFiles()
-                                ?.map {
-                                    ChapterDownloadProgress(
-                                        chapterUrl = it.absolutePath,
-                                        chapterName = chapterDir.name,
-                                        mangaTitle = titleDir.name,
-                                        state = DownloadState.Completed,
-                                    )
-                                }.orEmpty()
+                        ?.map { chapterDir ->
+                            ChapterDownloadProgress(
+                                chapterUrl = chapterDir.absolutePath,
+                                chapterName = chapterDir.name,
+                                mangaTitle = titleDir.name,
+                                state = DownloadState.Completed,
+                            )
                         }.orEmpty()
                 }.orEmpty()
 
-            println(completedFromDisk.joinToString("\n"))
-
             downloads + completedFromDisk.filter { it.chapterUrl !in activeUrls }
         }
+            .distinctUntilChanged()
+            .flowOn(Dispatchers.IO)
 
     actual fun deleteChapter(chapter: KmpChapterModel, mangaTitle: String) {
         File(rootDir, "${mangaTitle.sanitize()}/${chapter.name.sanitize()}").deleteRecursively()

--- a/mangaworld/shared/src/commonMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadScreen.kt
+++ b/mangaworld/shared/src/commonMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadScreen.kt
@@ -109,11 +109,13 @@ private fun DownloadViewer(
         .flow
         .collectAsStateWithLifecycle(initialValue = true)
 
-    val fileList = viewModel.fileList
+    val fileList by viewModel.fileList.collectAsStateWithLifecycle()
+
+    val fileEntries = remember(fileList) { fileList.entries.toList() }
 
     val activeDownloads by viewModel
         .activeDownloads
-        .collectAsStateWithLifecycle(emptyList())
+        .collectAsStateWithLifecycle()
 
     val inProgressDownloads by remember {
         derivedStateOf {
@@ -162,7 +164,8 @@ private fun DownloadViewer(
                     }
                 }
                 items(
-                    items = fileList.entries.toList()
+                    items = fileEntries,
+                    key = { it.key },
                 ) { file ->
                     ChapterItem(
                         file = file,
@@ -294,7 +297,7 @@ private fun ChapterItem(
         ) {
             ListItem(
                 modifier = Modifier.padding(4.dp),
-                headlineContent = { Text(file.value.values.randomOrNull()?.randomOrNull()?.folderName.orEmpty()) },
+                headlineContent = { Text(file.value.values.firstOrNull()?.firstOrNull()?.folderName.orEmpty()) },
                 supportingContent = { Text("Chapter Count ${file.value.size}") },
                 trailingContent = {
                     Icon(
@@ -308,7 +311,7 @@ private fun ChapterItem(
 
         if (expanded) {
             file.value.values.forEach { chapter ->
-                val c = chapter.randomOrNull()
+                val c = chapter.firstOrNull()
 
                 var showPopup by remember { mutableStateOf(false) }
 

--- a/mangaworld/shared/src/commonMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadViewModel.kt
+++ b/mangaworld/shared/src/commonMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadViewModel.kt
@@ -1,16 +1,15 @@
 package com.programmersbox.manga.shared.downloads
 
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.ui.util.fastMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
@@ -22,29 +21,31 @@ class DownloadViewModel(
     private val mangaDownloadManager: MangaDownloadManager,
 ) : ViewModel() {
 
-    val fileList = mutableStateMapOf<String, Map<String, List<DownloadedChapters>>>()
+    val fileList = downloadedMediaHandler
+        .listenToUpdates()
+        .map { f ->
+            f
+                .groupBy { it.folder }
+                .mapValues { entry -> entry.value.groupBy { c -> c.chapterFolder } }
+        }
+        .distinctUntilChanged()
+        .flowOn(Dispatchers.IO)
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyMap()
+        )
 
-    val activeDownloads = mangaDownloadManager.observeDownloads()
+    val activeDownloads = mangaDownloadManager
+        .observeDownloads()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList()
+        )
 
     init {
         downloadedMediaHandler.init("")
-
-        downloadedMediaHandler
-            .listenToUpdates()
-            .map { f ->
-                f
-                    .groupBy { it.folder }
-                    .entries
-                    .toList()
-                    .fastMap { it.key to it.value.groupBy { c -> c.chapterFolder } }
-                    .toMap()
-            }
-            .flowOn(Dispatchers.IO)
-            .onEach {
-                fileList.clear()
-                fileList.putAll(it)
-            }
-            .launchIn(viewModelScope)
     }
 
     fun cancelDownload(chapterUrl: String) {
@@ -52,7 +53,7 @@ class DownloadViewModel(
     }
 
     fun delete(downloadedChapters: DownloadedChapters) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             downloadedMediaHandler.delete(downloadedChapters)
         }
     }


### PR DESCRIPTION
…agement

- **DownloadedMediaHandler (Android)**: Implement a debounced refresh mechanism using `MutableSharedFlow` to coalesce rapid `MediaStore` updates.
- **DownloadedMediaHandler (Android)**: Add `CoroutineScope` management with `SupervisorJob` and ensure `ContentObserver` is registered on the main looper.
- **DownloadViewModel**: Refactor `fileList` and `activeDownloads` to use `StateFlow` via `stateIn` with a 5-second subscription timeout for better resource management.
- **DownloadViewModel**: Simplify the transformation of downloaded chapters into a grouped map using reactive operators like `distinctUntilChanged`.
- **DownloadScreen**: Optimize `LazyColumn` performance by adding unique keys to items and using `remember` for list transformations.
- **DownloadScreen**: Update UI logic to use `firstOrNull()` instead of `randomOrNull()` for more predictable display of folder and chapter names.
- **MangaDownloadManager (Android)**: Refine disk scanning in `observeDownloads` to track chapter directories rather than individual files, and apply `flowOn(Dispatchers.IO)`.
- **Cleanup**: Improve resource disposal in `DownloadedMediaHandler` by cancelling the coroutine scope and nulling out the observer on clear.