### PR TITLE
refactor(downloads): implement prefixed tagging for chapter downloads

### DIFF
--- a/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadChapterWorker.kt
+++ b/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/DownloadChapterWorker.kt
@@ -203,6 +203,12 @@ class DownloadChapterWorker(
         const val KEY_PROGRESS_TOTAL = "total"
         const val KEY_ERROR = "error"
         const val DOWNLOAD_TAG = "manga_chapter_download"
+
+        // Tag prefix for the chapter url. WorkManager auto-tags requests with the worker's
+        // class name, so a bare url tag can't be told apart from other tags reliably.
+        const val CHAPTER_URL_TAG_PREFIX = "chapterUrl:"
+
+        fun chapterUrlTag(chapterUrl: String) = "$CHAPTER_URL_TAG_PREFIX$chapterUrl"
         const val DOWNLOAD_QUEUE = "manga_download_queue"
     }
 }

--- a/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/MangaDownloadManager.android.kt
+++ b/mangaworld/shared/src/androidMain/kotlin/com/programmersbox/manga/shared/downloads/MangaDownloadManager.android.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -61,35 +62,39 @@ actual class MangaDownloadManager(
         workManager
             .getWorkInfosByTagFlow(DownloadChapterWorker.DOWNLOAD_TAG)
             .onEach { infos ->
-                _activeDownloads.value = infos
-                    .filter {
-                        it.state == WorkInfo.State.ENQUEUED ||
-                                it.state == WorkInfo.State.BLOCKED ||
-                                it.state == WorkInfo.State.RUNNING
-                    }
-                    .map { info ->
-                        val chapterUrl = info.tags
-                            .firstOrNull { it != DownloadChapterWorker.DOWNLOAD_TAG } ?: ""
-                        val chapterName = info.progress.getString(DownloadChapterWorker.KEY_CHAPTER_NAME) ?: ""
-                        val mangaTitle = info.progress.getString(DownloadChapterWorker.KEY_MANGA_TITLE) ?: ""
-                        ChapterDownloadProgress(
-                            chapterUrl = chapterUrl,
-                            chapterName = chapterName,
-                            mangaTitle = mangaTitle,
-                            state = when (info.state) {
-                                WorkInfo.State.ENQUEUED,
-                                WorkInfo.State.BLOCKED,
-                                    -> DownloadState.Queued
+                _activeDownloads.update {
+                    infos
+                        .filter {
+                            it.state == WorkInfo.State.ENQUEUED ||
+                                    it.state == WorkInfo.State.BLOCKED ||
+                                    it.state == WorkInfo.State.RUNNING
+                        }
+                        .map { info ->
+                            val chapterUrl = info.tags
+                                .firstOrNull { it.startsWith(DownloadChapterWorker.CHAPTER_URL_TAG_PREFIX) }
+                                ?.removePrefix(DownloadChapterWorker.CHAPTER_URL_TAG_PREFIX)
+                                ?: ""
+                            val chapterName = info.progress.getString(DownloadChapterWorker.KEY_CHAPTER_NAME) ?: ""
+                            val mangaTitle = info.progress.getString(DownloadChapterWorker.KEY_MANGA_TITLE) ?: ""
+                            ChapterDownloadProgress(
+                                chapterUrl = chapterUrl,
+                                chapterName = chapterName,
+                                mangaTitle = mangaTitle,
+                                state = when (info.state) {
+                                    WorkInfo.State.ENQUEUED,
+                                    WorkInfo.State.BLOCKED,
+                                        -> DownloadState.Queued
 
-                                WorkInfo.State.RUNNING -> DownloadState.Downloading(
-                                    imagesDownloaded = info.progress.getInt(DownloadChapterWorker.KEY_PROGRESS_DONE, 0),
-                                    totalImages = info.progress.getInt(DownloadChapterWorker.KEY_PROGRESS_TOTAL, 0),
-                                )
+                                    WorkInfo.State.RUNNING -> DownloadState.Downloading(
+                                        imagesDownloaded = info.progress.getInt(DownloadChapterWorker.KEY_PROGRESS_DONE, 0),
+                                        totalImages = info.progress.getInt(DownloadChapterWorker.KEY_PROGRESS_TOTAL, 0),
+                                    )
 
-                                else -> DownloadState.Queued
-                            },
-                        )
-                    }
+                                    else -> DownloadState.Queued
+                                },
+                            )
+                        }
+                }
                 // When a worker reaches a terminal state, tick so the filesystem check re-runs
                 if (infos.any {
                         it.state == WorkInfo.State.SUCCEEDED ||
@@ -141,7 +146,7 @@ actual class MangaDownloadManager(
             val workRequest = OneTimeWorkRequestBuilder<DownloadChapterWorker>()
                 .setInputData(inputData)
                 .addTag(DownloadChapterWorker.DOWNLOAD_TAG)
-                .addTag(chapter.url)
+                .addTag(DownloadChapterWorker.chapterUrlTag(chapter.url))
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(
@@ -172,7 +177,7 @@ actual class MangaDownloadManager(
     }
 
     actual fun cancelDownload(chapterUrl: String) {
-        workManager.cancelAllWorkByTag(chapterUrl)
+        workManager.cancelAllWorkByTag(DownloadChapterWorker.chapterUrlTag(chapterUrl))
     }
 
     actual fun cancelAll() {


### PR DESCRIPTION
- **MangaDownloadManager**: Update `_activeDownloads` state using `MutableStateFlow.update` for improved atomicity.
- **MangaDownloadManager**: Refactor tag retrieval to filter for tags starting with a specific prefix (`chapterUrl:`) instead of relying on tag order. This ensures the chapter URL is reliably identified among other WorkManager-generated tags.
- **MangaDownloadManager**: Update `downloadChapter` and `cancelDownload` to use the new `chapterUrlTag` helper for consistent tagging and cancellation.
- **DownloadChapterWorker**: Introduce `CHAPTER_URL_TAG_PREFIX` and a `chapterUrlTag` utility function to standardize how chapter URLs are stored as WorkManager tags.
- **BackgroundWorkHandlerImpl**: Add import for `kotlin.time.measureTime`.