### PR TITLE
feat(supabase): push local changes reactively on WiFi

### DIFF
--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/BookmarkDatabase.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/BookmarkDatabase.kt
@@ -91,6 +91,9 @@ interface BookmarkDao {
     @Query("SELECT * FROM bookmarked_chapters WHERE is_dirty = 1")
     suspend fun getDirtyBookmarks(): List<BookmarkedChapter>
 
+    @Query("SELECT COUNT(*) FROM bookmarked_chapters WHERE is_dirty = 1")
+    fun observeDirtyBookmarkCount(): Flow<Int>
+
     @Query("SELECT * FROM bookmarked_chapters WHERE chapterUrl = :chapterUrl")
     suspend fun getBookmarkByChapterUrl(chapterUrl: String): BookmarkedChapter?
 

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/CustomList.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/CustomList.kt
@@ -189,8 +189,14 @@ interface ListDao {
     @Query("SELECT * FROM CustomListItem WHERE is_dirty = 1")
     suspend fun getDirtyCustomListItems(): List<CustomListItem>
 
+    @Query("SELECT COUNT(*) FROM CustomListItem WHERE is_dirty = 1")
+    fun observeDirtyCustomListItemCount(): Flow<Int>
+
     @Query("SELECT * FROM CustomListInfo WHERE is_dirty = 1")
     suspend fun getDirtyCustomListInfo(): List<CustomListInfo>
+
+    @Query("SELECT COUNT(*) FROM CustomListInfo WHERE is_dirty = 1")
+    fun observeDirtyCustomListInfoCount(): Flow<Int>
 
     @Query("SELECT * FROM CustomListItem WHERE uuid = :uuid")
     suspend fun getCustomListItemByUuid(uuid: String): CustomListItem?

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/HeatMapDatabase.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/HeatMapDatabase.kt
@@ -91,6 +91,9 @@ interface HeatMapDao {
     @Query("SELECT * FROM HeatMapItem WHERE is_dirty = 1")
     suspend fun getDirtyHeatMapItems(): List<HeatMapItem>
 
+    @Query("SELECT COUNT(*) FROM HeatMapItem WHERE is_dirty = 1")
+    fun observeDirtyHeatMapCount(): Flow<Int>
+
     @Query("SELECT * FROM HeatMapItem WHERE time = :time LIMIT 1")
     suspend fun getHeatMapItemByTime(time: LocalDate): HeatMapItem?
 

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/HistoryDatabase.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/HistoryDatabase.kt
@@ -103,6 +103,9 @@ interface HistoryDao {
     @Query("SELECT * FROM History WHERE is_dirty = 1")
     suspend fun getDirtyHistory(): List<HistoryItem>
 
+    @Query("SELECT COUNT(*) FROM History WHERE is_dirty = 1")
+    fun observeDirtyHistoryCount(): Flow<Int>
+
     @Query("SELECT * FROM RecentlyViewed WHERE is_dirty = 1")
     suspend fun getDirtyRecentlyViewed(): List<RecentModel>
 

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/ItemDao.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/ItemDao.kt
@@ -66,6 +66,9 @@ interface ItemDao {
     @Query("SELECT * FROM ChapterWatched where favoriteUrl = :url AND is_deleted = 0")
     fun getAllChapters(url: String): Flow<List<ChapterWatched>>
 
+    @Query("SELECT * FROM ChapterWatched")
+    fun getTrulyAllChapters(): Flow<List<ChapterWatched>>
+
     @Query("SELECT * FROM ChapterWatched where favoriteUrl = :url")
     suspend fun getAllChaptersSync(url: String): List<ChapterWatched>
 
@@ -188,6 +191,9 @@ interface ItemDao {
     @Query("SELECT * FROM FavoriteItem WHERE is_dirty = 1")
     suspend fun getDirtyFavorites(): List<DbModel>
 
+    @Query("SELECT COUNT(*) FROM FavoriteItem WHERE is_dirty = 1")
+    fun observeDirtyFavoriteCount(): Flow<Int>
+
     @Query("SELECT * FROM FavoriteItem WHERE url = :url")
     suspend fun getFavoriteByUrl(url: String): DbModel?
 
@@ -196,6 +202,9 @@ interface ItemDao {
 
     @Query("SELECT * FROM ChapterWatched WHERE is_dirty = 1")
     suspend fun getDirtyChapters(): List<ChapterWatched>
+
+    @Query("SELECT COUNT(*) FROM ChapterWatched WHERE is_dirty = 1")
+    fun observeDirtyChapterCount(): Flow<Int>
 
     @Query("SELECT * FROM ChapterWatched WHERE url = :url")
     suspend fun getChapterByUrl(url: String): ChapterWatched?

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/NotesDatabase.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/NotesDatabase.kt
@@ -75,6 +75,9 @@ interface NotesDao {
     @Query("SELECT * FROM notes WHERE is_dirty = 1")
     suspend fun getDirtyNotes(): List<NoteItem>
 
+    @Query("SELECT COUNT(*) FROM notes WHERE is_dirty = 1")
+    fun observeDirtyNoteCount(): Flow<Int>
+
     @Query("SELECT * FROM notes WHERE itemUrl = :itemUrl")
     suspend fun getNoteByUrl(itemUrl: String): NoteItem?
 

--- a/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncEngine.kt
+++ b/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncEngine.kt
@@ -2,12 +2,15 @@ package com.programmersbox.supabaseintegration.sync
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 
 interface SyncEngine {
     suspend fun pushLocalChanges()
     /** Pull remote changes. [tables] restricts which tables are fetched; null = all tables. */
     suspend fun pullRemoteChanges(since: Long, tables: Set<String>? = null)
     suspend fun fullSync()
+    /** Emits whenever any local table has rows with is_dirty=1. Use on WiFi to push changes reactively. */
+    fun observeLocalChanges(): Flow<Unit>
     /**
      * Opens a Supabase Realtime channel that watches all 8 sync tables for the current user.
      * Calls [onEvent] with the set of table names that changed (coalesced per batch).

--- a/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncEngineImpl.kt
+++ b/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncEngineImpl.kt
@@ -23,7 +23,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
@@ -506,6 +510,17 @@ class SyncEngineImpl(
             println("$direction $dbId took $duration")
         }
     }
+
+    override fun observeLocalChanges(): Flow<Unit> = merge(
+        itemDao.observeDirtyFavoriteCount(),
+        itemDao.observeDirtyChapterCount(),
+        bookmarkDao.observeDirtyBookmarkCount(),
+        historyDao.observeDirtyHistoryCount(),
+        notesDao.observeDirtyNoteCount(),
+        listDao.observeDirtyCustomListItemCount(),
+        listDao.observeDirtyCustomListInfoCount(),
+        heatMapDao.observeDirtyHeatMapCount(),
+    ).filter { it > 0 }.map { }
 
     override suspend fun fullSync() {
         pushLocalChanges()

--- a/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncManager.kt
+++ b/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/sync/SyncManager.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.FlowPreview::class)
+
 package com.programmersbox.supabaseintegration.sync
 
 import com.programmersbox.supabaseintegration.auth.AuthManager
@@ -14,11 +16,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class SyncManager(
     private val syncEngine: SyncEngine,
@@ -76,8 +81,6 @@ class SyncManager(
     }
 
     private fun startWifi() {
-        //TODO: Listen for updates to each of the tables and when they are updated, push them
-        
         println("Starting realtime listening")
         realtimeJob?.cancel()
         realtimeJob = scope.launch {
@@ -86,6 +89,20 @@ class SyncManager(
                 withRetry { doSync() }
             } catch (e: Exception) {
                 _syncState.value = SyncState.Error(e.message ?: "Sync failed")
+            }
+
+            // Push local changes reactively: any is_dirty row → debounce 1s → push only.
+            launch {
+                syncEngine
+                    .observeLocalChanges()
+                    .debounce(1.seconds)
+                    .collect {
+                        try {
+                            withRetry { syncEngine.pushLocalChanges() }
+                        } catch (e: Exception) {
+                            _syncState.value = SyncState.Error(e.message ?: "Push failed")
+                        }
+                    }
             }
 
             // Realtime subscription — onEvent receives only the tables that changed.
@@ -109,7 +126,7 @@ class SyncManager(
         if (pollingJob?.isActive == true) return
         pollingJob = scope.launch {
             while (isActive) {
-                delay(config.value.pollIntervalMs)
+                delay(config.value.pollIntervalMs.milliseconds)
                 if (connectivityMonitor.isOnline.value) {
                     try {
                         withRetry { doSync() }
@@ -161,7 +178,7 @@ class SyncManager(
                 .onFailure { e ->
                     attempt++
                     if (attempt > cfg.maxRetries) throw e
-                    delay(backoff)
+                    delay(backoff.milliseconds)
                     backoff = minOf(backoff * 2, cfg.maxBackoffMs)
                 }
         }


### PR DESCRIPTION
Each DAO gets a Flow<Int> dirty-count query (observeDirtyXCount) that Room re-emits whenever the underlying table changes. SyncEngineImpl merges all 8 dirty-count flows into observeLocalChanges(): Flow<Unit>, filtering for count > 0.

On WiFi, SyncManager collects observeLocalChanges() with a 1-second debounce (coalesces rapid writes) and calls pushLocalChanges(). No pull is triggered — Realtime handles the reverse direction. Together:

  local write → is_dirty=1 → observeLocalChanges emits → 1s debounce
  → pushLocalChanges() → Supabase updated → Realtime fires on other
  devices → those devices pull only the changed table.