### PR TITLE
feat(ui): implement custom backdrop system and migrate from external …

### DIFF
--- a/kmpuiviews/build.gradle.kts
+++ b/kmpuiviews/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
                 api(commonLibs.haze)
                 api(commonLibs.haze.blur)
                 api(commonLibs.haze.materials)
-                api(commonLibs.backdrop)
+                //api(commonLibs.backdrop)
                 implementation(commonLibs.material.kolor)
                 api(commonLibs.kamel.image)
                 api(commonLibs.kamel.decoder.animated.image)
@@ -241,6 +241,12 @@ kotlin {
             dependsOn(commonMain.get())
             androidMain.get().dependsOn(this)
             jvmMain.get().dependsOn(this)
+        }
+
+        val skikoMain by creating {
+            dependsOn(commonMain.get())
+            jvmMain.get().dependsOn(this)
+            iosMain.get().dependsOn(this)
         }
 
         all {

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.android.kt
@@ -1,0 +1,10 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+@ChecksSdkIntAtLeast(Build.VERSION_CODES.S)
+actual fun isRenderEffectSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+@ChecksSdkIntAtLeast(Build.VERSION_CODES.TIRAMISU)
+actual fun isRuntimeShaderSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.android.kt
@@ -1,0 +1,70 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.toArgb
+import org.intellij.lang.annotations.Language
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+actual fun BackdropRuntimeShader(@Language("AGSL") shaderString: String): BackdropRuntimeShader {
+    val shader = android.graphics.RuntimeShader(shaderString)
+    return AndroidRuntimeShader(shader)
+}
+
+actual fun BackdropRuntimeShader.asComposeShader(): Shader {
+    return this.asAndroidRuntimeShader()
+}
+
+fun BackdropRuntimeShader.asAndroidRuntimeShader(): android.graphics.RuntimeShader {
+    return (this as AndroidRuntimeShader).shader
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+internal class AndroidRuntimeShader(val shader: android.graphics.RuntimeShader) : BackdropRuntimeShader {
+
+    override fun setFloatUniform(name: String, value: Float) {
+        shader.setFloatUniform(name, value)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float) {
+        shader.setFloatUniform(name, value1, value2)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float) {
+        shader.setFloatUniform(name, value1, value2, value3)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float) {
+        shader.setFloatUniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setFloatUniform(name: String, values: FloatArray) {
+        shader.setFloatUniform(name, values)
+    }
+
+    override fun setIntUniform(name: String, value: Int) {
+        shader.setIntUniform(name, value)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int) {
+        shader.setIntUniform(name, value1, value2)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int) {
+        shader.setIntUniform(name, value1, value2, value3)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int) {
+        shader.setIntUniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setIntUniform(name: String, values: IntArray) {
+        shader.setIntUniform(name, values)
+    }
+
+    override fun setColorUniform(name: String, color: Color) {
+        shader.setColorUniform(name, color.toArgb())
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.android.kt
@@ -1,0 +1,17 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.nativePaint
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.asAndroidRuntimeShader
+
+internal actual fun Paint.blur(radius: Float) {
+    this.nativePaint.maskFilter =
+        if (radius > 0f) BlurMaskFilter(radius, BlurMaskFilter.Blur.NORMAL)
+        else null
+}
+
+internal actual fun Paint.setRuntimeShader(runtimeShader: BackdropRuntimeShader?) {
+    this.nativePaint.shader = runtimeShader?.asAndroidRuntimeShader()
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.android.kt
@@ -1,0 +1,50 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.asAndroidColorFilter
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.asAndroidRuntimeShader
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal actual fun RenderEffect?.chain(other: RenderEffect): RenderEffect {
+    return if (this != null) {
+        android.graphics.RenderEffect.createChainEffect(
+            other.asAndroidRenderEffect(),
+            this.asAndroidRenderEffect()
+        ).asComposeRenderEffect()
+    } else {
+        other
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+internal actual fun RuntimeShaderEffect(
+    runtimeShader: BackdropRuntimeShader,
+    uniformShaderName: String,
+): RenderEffect {
+    return android.graphics.RenderEffect.createRuntimeShaderEffect(
+        runtimeShader.asAndroidRuntimeShader(),
+        uniformShaderName
+    ).asComposeRenderEffect()
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal actual fun ColorFilterEffect(
+    renderEffect: RenderEffect?,
+    colorFilter: ColorFilter,
+): RenderEffect {
+    return if (renderEffect != null) {
+        android.graphics.RenderEffect.createColorFilterEffect(
+            colorFilter.asAndroidColorFilter(),
+            renderEffect.asAndroidRenderEffect()
+        ).asComposeRenderEffect()
+    } else {
+        android.graphics.RenderEffect.createColorFilterEffect(
+            colorFilter.asAndroidColorFilter(),
+        ).asComposeRenderEffect()
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/about/AboutLIbrariesScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/about/AboutLIbrariesScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,7 +49,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Developer
 import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.entity.License
+import com.mikepenz.aboutlibraries.entity.Scm
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.LibraryPadding
 import com.mikepenz.aboutlibraries.ui.compose.util.author
@@ -70,7 +74,36 @@ fun AboutLibrariesScreen() {
     val aboutLibraryBuilder = koinInject<AboutLibraryBuilder>()
     val libraries by aboutLibraryBuilder.buildLibs()
 
-    val libs = libraries?.libraries.orEmpty()
+    val libs by remember(libraries) {
+        derivedStateOf {
+            libraries?.libraries.orEmpty() + Library(
+                uniqueId = "io.github.kyant0:backdrop",
+                artifactVersion = "2.0.0-custom",
+                name = "Backdrop",
+                description = "Compose Multiplatform Liquid Glass effects",
+                website = "https://github.com/Kyant0/AndroidLiquidGlass",
+                licenses = setOf(
+                    License(
+                        name = "The Apache License, Version 2.0",
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                        hash = ""
+                    )
+                ),
+                developers = listOf(
+                    Developer(
+                        name = "Kyant0",
+                        organisationUrl = "https://github.com/Kyant0"
+                    )
+                ),
+                organization = null,
+                scm = Scm(
+                    url = "https://github.com/Kyant0/AndroidLiquidGlass",
+                    connection = "scm:git:git://github.com/Kyant0/AndroidLiquidGlass.git",
+                    developerConnection = "scm:git:ssh://git@github.com/Kyant0/AndroidLiquidGlass.git",
+                )
+            )
+        }
+    }
 
     val topAppBarScrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/blurkind/BlurKindLiquidGlass.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/blurkind/BlurKindLiquidGlass.kt
@@ -10,14 +10,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
-import com.kyant.backdrop.backdrops.LayerBackdrop
-import com.kyant.backdrop.backdrops.rememberLayerBackdrop
-import com.kyant.backdrop.drawBackdrop
-import com.kyant.backdrop.effects.blur
-import com.kyant.backdrop.effects.lens
-import com.kyant.backdrop.effects.vibrancy
-import com.kyant.backdrop.highlight.Highlight
 import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops.LayerBackdrop
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops.rememberLayerBackdrop
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.drawBackdrop
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects.blur
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects.lens
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects.vibrancy
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight.Highlight
 import org.koin.compose.koinInject
 
 @Composable

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/blurkind/BlurKindModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/blurkind/BlurKindModifier.kt
@@ -10,9 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
-import com.kyant.backdrop.backdrops.layerBackdrop
 import com.programmersbox.datastore.BlurKind
 import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops.layerBackdrop
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.hazeEffect

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/Backdrop.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/Backdrop.kt
@@ -1,0 +1,17 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.unit.Density
+
+interface Backdrop {
+
+    val isCoordinatesDependent: Boolean
+
+    fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    )
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropEffectScope.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropEffectScope.kt
@@ -1,0 +1,74 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+
+sealed interface BackdropEffectScope : Density, BackdropRuntimeShaderCache {
+
+    val size: Size
+
+    val layoutDirection: LayoutDirection
+
+    val shape: Shape
+
+    var padding: Float
+
+    var renderEffect: RenderEffect?
+}
+
+internal abstract class BackdropEffectScopeImpl : BackdropEffectScope, BackdropRuntimeShaderCache {
+
+    override var density: Float = 1f
+    override var fontScale: Float = 1f
+    override var size: Size = Size.Unspecified
+    override var layoutDirection: LayoutDirection = LayoutDirection.Ltr
+    override var padding: Float = 0f
+    override var renderEffect: RenderEffect? = null
+
+    private val runtimeShaderCache = BackdropRuntimeShaderCacheImpl()
+
+    override fun obtainRuntimeShader(key: String, string: String): BackdropRuntimeShader {
+        return runtimeShaderCache.obtainRuntimeShader(key, string)
+    }
+
+    fun update(scope: DrawScope): Boolean {
+        val newDensity = scope.density
+        val newFontScale = scope.fontScale
+        val newSize = scope.size
+        val newLayoutDirection = scope.layoutDirection
+
+        val changed = newDensity != density ||
+                newFontScale != fontScale ||
+                newSize != size ||
+                newLayoutDirection != layoutDirection
+
+        if (changed) {
+            density = newDensity
+            fontScale = newFontScale
+            size = newSize
+            layoutDirection = newLayoutDirection
+        }
+
+        return changed
+    }
+
+    fun apply(effects: BackdropEffectScope.() -> Unit) {
+        padding = 0f
+        renderEffect = null
+        effects()
+    }
+
+    fun reset() {
+        density = 1f
+        fontScale = 1f
+        size = Size.Unspecified
+        layoutDirection = LayoutDirection.Ltr
+        padding = 0f
+        renderEffect = null
+        runtimeShaderCache.clear()
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.kt
@@ -1,0 +1,5 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+expect fun isRenderEffectSupported(): Boolean
+
+expect fun isRuntimeShaderSupported(): Boolean

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.kt
@@ -1,0 +1,26 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shader
+import org.intellij.lang.annotations.Language
+
+expect fun BackdropRuntimeShader(@Language("AGSL") shaderString: String): BackdropRuntimeShader
+
+expect fun BackdropRuntimeShader.asComposeShader(): Shader
+
+interface BackdropRuntimeShader {
+
+    fun setFloatUniform(name: String, value: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float)
+    fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float)
+    fun setFloatUniform(name: String, values: FloatArray)
+
+    fun setIntUniform(name: String, value: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int)
+    fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int)
+    fun setIntUniform(name: String, values: IntArray)
+
+    fun setColorUniform(name: String, color: Color)
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShaderCache.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShaderCache.kt
@@ -1,0 +1,21 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import org.intellij.lang.annotations.Language
+
+sealed interface BackdropRuntimeShaderCache {
+
+    fun obtainRuntimeShader(key: String, @Language("AGSL") string: String): BackdropRuntimeShader
+}
+
+internal class BackdropRuntimeShaderCacheImpl : BackdropRuntimeShaderCache {
+
+    private val runtimeShaders = mutableMapOf<String, BackdropRuntimeShader>()
+
+    override fun obtainRuntimeShader(key: String, string: String): BackdropRuntimeShader {
+        return runtimeShaders.getOrPut(key) { BackdropRuntimeShader(string) }
+    }
+
+    fun clear() {
+        runtimeShaders.clear()
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/DrawBackdropModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/DrawBackdropModifier.kt
@@ -1,0 +1,388 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops.LayerBackdrop
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight.Highlight
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight.HighlightElement
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.ShapeProvider
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.recordLayer
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow.InnerShadow
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow.InnerShadowElement
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow.Shadow
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow.ShadowElement
+
+private val DefaultHighlight = { Highlight.Default }
+private val DefaultShadow = { Shadow.Default }
+private val DefaultOnDrawBackdrop: DrawScope.(DrawScope.() -> Unit) -> Unit = { it() }
+
+fun Modifier.drawPlainBackdrop(
+    backdrop: Backdrop,
+    shape: () -> Shape,
+    effects: BackdropEffectScope.() -> Unit,
+    layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    exportedBackdrop: LayerBackdrop? = null,
+    onDrawBehind: (DrawScope.() -> Unit)? = null,
+    onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit = DefaultOnDrawBackdrop,
+    onDrawSurface: (DrawScope.() -> Unit)? = null,
+    onDrawFront: (DrawScope.() -> Unit)? = null,
+): Modifier {
+    val shapeProvider = ShapeProvider(shape)
+    return this
+        .then(
+            if (layerBlock != null) {
+                Modifier.graphicsLayer(layerBlock)
+            } else {
+                Modifier
+            }
+        )
+        .then(
+            DrawBackdropElement(
+                backdrop = backdrop,
+                shapeProvider = shapeProvider,
+                effects = effects,
+                layerBlock = layerBlock,
+                exportedBackdrop = exportedBackdrop,
+                onDrawBehind = onDrawBehind,
+                onDrawBackdrop = onDrawBackdrop,
+                onDrawSurface = onDrawSurface,
+                onDrawFront = onDrawFront
+            )
+        )
+}
+
+fun Modifier.drawBackdrop(
+    backdrop: Backdrop,
+    shape: () -> Shape,
+    effects: BackdropEffectScope.() -> Unit,
+    highlight: (() -> Highlight?)? = DefaultHighlight,
+    shadow: (() -> Shadow?)? = DefaultShadow,
+    innerShadow: (() -> InnerShadow?)? = null,
+    layerBlock: (GraphicsLayerScope.() -> Unit)? = null,
+    exportedBackdrop: LayerBackdrop? = null,
+    onDrawBehind: (DrawScope.() -> Unit)? = null,
+    onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit = DefaultOnDrawBackdrop,
+    onDrawSurface: (DrawScope.() -> Unit)? = null,
+    onDrawFront: (DrawScope.() -> Unit)? = null,
+): Modifier {
+    val shapeProvider = ShapeProvider(shape)
+    return this
+        .then(
+            if (layerBlock != null) {
+                Modifier.graphicsLayer(layerBlock)
+            } else {
+                Modifier
+            }
+        )
+        .then(
+            if (innerShadow != null) {
+                InnerShadowElement(
+                    shapeProvider = shapeProvider,
+                    shadow = innerShadow
+                )
+            } else {
+                Modifier
+            }
+        )
+        .then(
+            if (shadow != null) {
+                ShadowElement(
+                    shapeProvider = shapeProvider,
+                    shadow = shadow
+                )
+            } else {
+                Modifier
+            }
+        )
+        .then(
+            if (highlight != null) {
+                HighlightElement(
+                    shapeProvider = shapeProvider,
+                    highlight = highlight
+                )
+            } else {
+                Modifier
+            }
+        )
+        .then(
+            DrawBackdropElement(
+                backdrop = backdrop,
+                shapeProvider = shapeProvider,
+                effects = effects,
+                layerBlock = layerBlock,
+                exportedBackdrop = exportedBackdrop,
+                onDrawBehind = onDrawBehind,
+                onDrawBackdrop = onDrawBackdrop,
+                onDrawSurface = onDrawSurface,
+                onDrawFront = onDrawFront
+            )
+        )
+}
+
+private class DrawBackdropElement(
+    val backdrop: Backdrop,
+    val shapeProvider: ShapeProvider,
+    val effects: BackdropEffectScope.() -> Unit,
+    val layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    val exportedBackdrop: LayerBackdrop?,
+    val onDrawBehind: (DrawScope.() -> Unit)?,
+    val onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+    val onDrawSurface: (DrawScope.() -> Unit)?,
+    val onDrawFront: (DrawScope.() -> Unit)?,
+) : ModifierNodeElement<DrawBackdropNode>() {
+
+    override fun create(): DrawBackdropNode {
+        return DrawBackdropNode(
+            backdrop = backdrop,
+            shapeProvider = shapeProvider,
+            effects = effects,
+            layerBlock = layerBlock,
+            exportedBackdrop = exportedBackdrop,
+            onDrawBehind = onDrawBehind,
+            onDrawBackdrop = onDrawBackdrop,
+            onDrawSurface = onDrawSurface,
+            onDrawFront = onDrawFront
+        )
+    }
+
+    override fun update(node: DrawBackdropNode) {
+        node.backdrop = backdrop
+        node.shapeProvider = shapeProvider
+        node.effects = effects
+        node.layerBlock = layerBlock
+        if (node.exportedBackdrop != exportedBackdrop) {
+            node.exportedBackdrop?.layerCoordinates = null
+            node.exportedBackdrop = exportedBackdrop
+        }
+        node.onDrawBehind = onDrawBehind
+        node.onDrawBackdrop = onDrawBackdrop
+        node.onDrawSurface = onDrawSurface
+        node.onDrawFront = onDrawFront
+        node.invalidateDrawCache()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "drawBackdrop"
+        properties["backdrop"] = backdrop
+        properties["shapeProvider"] = shapeProvider
+        properties["effects"] = effects
+        properties["layerBlock"] = layerBlock
+        properties["exportedBackdrop"] = exportedBackdrop
+        properties["onDrawBehind"] = onDrawBehind
+        properties["onDrawBackdrop"] = onDrawBackdrop
+        properties["onDrawSurface"] = onDrawSurface
+        properties["onDrawFront"] = onDrawFront
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DrawBackdropElement) return false
+
+        if (backdrop != other.backdrop) return false
+        if (shapeProvider != other.shapeProvider) return false
+        if (effects != other.effects) return false
+        if (layerBlock != other.layerBlock) return false
+        if (exportedBackdrop != other.exportedBackdrop) return false
+        if (onDrawBehind != other.onDrawBehind) return false
+        if (onDrawBackdrop != other.onDrawBackdrop) return false
+        if (onDrawSurface != other.onDrawSurface) return false
+        if (onDrawFront != other.onDrawFront) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = backdrop.hashCode()
+        result = 31 * result + shapeProvider.hashCode()
+        result = 31 * result + effects.hashCode()
+        result = 31 * result + (layerBlock?.hashCode() ?: 0)
+        result = 31 * result + (exportedBackdrop?.hashCode() ?: 0)
+        result = 31 * result + (onDrawBehind?.hashCode() ?: 0)
+        result = 31 * result + onDrawBackdrop.hashCode()
+        result = 31 * result + (onDrawSurface?.hashCode() ?: 0)
+        result = 31 * result + (onDrawFront?.hashCode() ?: 0)
+        return result
+    }
+}
+
+private class DrawBackdropNode(
+    var backdrop: Backdrop,
+    var shapeProvider: ShapeProvider,
+    var effects: BackdropEffectScope.() -> Unit,
+    var layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    var exportedBackdrop: LayerBackdrop?,
+    var onDrawBehind: (DrawScope.() -> Unit)?,
+    var onDrawBackdrop: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+    var onDrawSurface: (DrawScope.() -> Unit)?,
+    var onDrawFront: (DrawScope.() -> Unit)?,
+) : LayoutModifierNode, DrawModifierNode, GlobalPositionAwareModifierNode, ObserverModifierNode, Modifier.Node() {
+
+    private val effectScope =
+        object : BackdropEffectScopeImpl() {
+
+            override val shape: Shape get() = shapeProvider.innerShape
+        }
+
+    private var graphicsLayer: GraphicsLayer? = null
+
+    private val layoutLayerBlock: GraphicsLayerScope.() -> Unit = {
+        clip = true
+        shape = shapeProvider.shape
+        compositingStrategy = androidx.compose.ui.graphics.CompositingStrategy.Offscreen
+    }
+
+    private var layoutCoordinates: LayoutCoordinates? by mutableStateOf(null, neverEqualPolicy())
+
+    private var padding by mutableFloatStateOf(0f)
+
+    private val recordBackdropBlock: (DrawScope.() -> Unit) = {
+        val canvas = drawContext.canvas
+        val padding = padding
+
+        if (padding != 0f) {
+            canvas.translate(padding, padding)
+        }
+        onDrawBackdrop {
+            with(backdrop) {
+                drawBackdrop(
+                    density = effectScope,
+                    coordinates = layoutCoordinates,
+                    layerBlock = layerBlock
+                )
+            }
+        }
+        if (padding != 0f) {
+            canvas.translate(-padding, -padding)
+        }
+    }
+
+    private val drawBackdropLayer: DrawScope.() -> Unit = {
+        val layer = graphicsLayer
+        if (layer != null) {
+            val padding = padding
+
+            recordLayer(
+                layer,
+                size = IntSize(
+                    size.width.toInt() + padding.toInt() * 2,
+                    size.height.toInt() + padding.toInt() * 2
+                ),
+                block = recordBackdropBlock
+            )
+
+            layer.topLeft =
+                if (padding != 0f) IntOffset(-padding.toInt(), -padding.toInt())
+                else IntOffset.Zero
+            drawLayer(layer)
+        }
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeWithLayer(IntOffset.Zero, layerBlock = layoutLayerBlock)
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        if (effectScope.update(this)) {
+            updateEffects()
+        }
+
+        onDrawBehind?.invoke(this)
+        drawBackdropLayer()
+        onDrawSurface?.invoke(this)
+        drawContent()
+        onDrawFront?.invoke(this)
+
+        exportedBackdrop?.graphicsLayer?.let { layer ->
+            recordLayer(layer) {
+                onDrawBehind?.invoke(this)
+                drawBackdropLayer()
+                onDrawSurface?.invoke(this)
+                onDrawFront?.invoke(this)
+            }
+        }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        if (coordinates.isAttached) {
+            if (backdrop.isCoordinatesDependent) {
+                layoutCoordinates = coordinates
+            } else {
+                if (layoutCoordinates != null) {
+                    layoutCoordinates = null
+                }
+            }
+            exportedBackdrop?.layerCoordinates = coordinates
+        }
+    }
+
+    override fun onObservedReadsChanged() {
+        invalidateDrawCache()
+    }
+
+    fun invalidateDrawCache() {
+        observeEffects()
+    }
+
+    private fun observeEffects() {
+        observeReads { updateEffects() }
+    }
+
+    private fun updateEffects() {
+        if (!isRenderEffectSupported()) return
+
+        effectScope.apply(effects)
+        graphicsLayer?.renderEffect = effectScope.renderEffect
+        padding = effectScope.padding
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        graphicsLayer = graphicsContext.createGraphicsLayer()
+
+        observeEffects()
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        graphicsLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            graphicsLayer = null
+        }
+
+        effectScope.reset()
+        layoutCoordinates = null
+        exportedBackdrop?.layerCoordinates = null
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/backdrops/LayerBackdrop.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/backdrops/LayerBackdrop.kt
@@ -1,0 +1,232 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.Density
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.Backdrop
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.InverseLayerScope
+
+private val DefaultOnDraw: ContentDrawScope.() -> Unit = { drawContent() }
+
+@Composable
+fun rememberLayerBackdrop(
+    graphicsLayer: GraphicsLayer = rememberGraphicsLayer(),
+    onDraw: ContentDrawScope.() -> Unit = DefaultOnDraw,
+): LayerBackdrop {
+    return remember(graphicsLayer, onDraw) {
+        LayerBackdrop(graphicsLayer, onDraw)
+    }
+}
+
+@Stable
+class LayerBackdrop internal constructor(
+    val graphicsLayer: GraphicsLayer,
+    internal val onDraw: ContentDrawScope.() -> Unit,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean = true
+
+    internal var layerCoordinates: LayoutCoordinates? by mutableStateOf(null)
+
+    private var inverseLayerScope: InverseLayerScope? = null
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        val coordinates = coordinates ?: return
+        val layerCoordinates = layerCoordinates ?: return
+        withTransform({
+            if (layerBlock != null) {
+                with(obtainInverseLayerScope()) { inverseTransform(density, layerBlock) }
+            }
+            val offset =
+                try {
+                    layerCoordinates.localPositionOf(coordinates)
+                } catch (_: Exception) {
+                    // TODO: outer transformations lead to wrong position calculation
+                    coordinates.positionInWindow() - layerCoordinates.positionInWindow()
+                }
+            translate(-offset.x, -offset.y)
+        }) {
+            drawLayer(graphicsLayer)
+        }
+    }
+
+    private fun obtainInverseLayerScope(): InverseLayerScope {
+        return inverseLayerScope?.apply { reset() }
+            ?: InverseLayerScope().also { inverseLayerScope = it }
+    }
+}
+
+@Stable
+fun emptyBackdrop(): Backdrop = EmptyBackdrop
+
+@Immutable
+private object EmptyBackdrop : Backdrop {
+
+    override val isCoordinatesDependent: Boolean = false
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+    }
+}
+
+@Composable
+fun rememberCombinedBackdrop(
+    backdrop1: Backdrop,
+    backdrop2: Backdrop,
+): Backdrop {
+    return remember(backdrop1, backdrop2) {
+        Combined2Backdrops(backdrop1, backdrop2)
+    }
+}
+
+@Composable
+fun rememberCombinedBackdrop(
+    backdrop1: Backdrop,
+    backdrop2: Backdrop,
+    backdrop3: Backdrop,
+): Backdrop {
+    return remember(backdrop1, backdrop2, backdrop3) {
+        Combined3Backdrops(backdrop1, backdrop2, backdrop3)
+    }
+}
+
+@Composable
+fun rememberCombinedBackdrop(vararg backdrops: Backdrop): Backdrop {
+    return remember(*backdrops) {
+        CombinedBackdrops(*backdrops)
+    }
+}
+
+@Immutable
+private class Combined2Backdrops(
+    val backdrop1: Backdrop,
+    val backdrop2: Backdrop,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean =
+        backdrop1.isCoordinatesDependent || backdrop2.isCoordinatesDependent
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        with(backdrop1) { drawBackdrop(density, coordinates, layerBlock) }
+        with(backdrop2) { drawBackdrop(density, coordinates, layerBlock) }
+    }
+}
+
+@Immutable
+private class Combined3Backdrops(
+    val backdrop1: Backdrop,
+    val backdrop2: Backdrop,
+    val backdrop3: Backdrop,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean =
+        backdrop1.isCoordinatesDependent ||
+                backdrop2.isCoordinatesDependent ||
+                backdrop3.isCoordinatesDependent
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        with(backdrop1) { drawBackdrop(density, coordinates, layerBlock) }
+        with(backdrop2) { drawBackdrop(density, coordinates, layerBlock) }
+        with(backdrop3) { drawBackdrop(density, coordinates, layerBlock) }
+    }
+}
+
+@Immutable
+private class CombinedBackdrops(
+    vararg val backdrops: Backdrop,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean =
+        backdrops.any { it.isCoordinatesDependent }
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        backdrops.forEach { backdrop ->
+            with(backdrop) { drawBackdrop(density, coordinates, layerBlock) }
+        }
+    }
+}
+
+@Composable
+fun rememberCanvasBackdrop(
+    onDraw: DrawScope.() -> Unit,
+): Backdrop {
+    return remember(onDraw) {
+        CanvasBackdrop(onDraw)
+    }
+}
+
+@Immutable
+private class CanvasBackdrop(
+    val onDraw: DrawScope.() -> Unit,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean = false
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        onDraw()
+    }
+}
+
+@Composable
+fun rememberBackdrop(
+    backdrop: Backdrop,
+    onDraw: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+): Backdrop {
+    return remember(backdrop, onDraw) {
+        Backdrop(backdrop, onDraw)
+    }
+}
+
+@Immutable
+private class Backdrop(
+    val backdrop: Backdrop,
+    val onDraw: DrawScope.(drawBackdrop: DrawScope.() -> Unit) -> Unit,
+) : Backdrop {
+
+    override val isCoordinatesDependent: Boolean = backdrop.isCoordinatesDependent
+
+    override fun DrawScope.drawBackdrop(
+        density: Density,
+        coordinates: LayoutCoordinates?,
+        layerBlock: (GraphicsLayerScope.() -> Unit)?,
+    ) {
+        onDraw { with(backdrop) { drawBackdrop(density, coordinates, layerBlock) } }
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/backdrops/LayerBackdropModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/backdrops/LayerBackdropModifier.kt
@@ -1,0 +1,69 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.backdrops
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.platform.InspectorInfo
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.recordLayer
+
+fun Modifier.layerBackdrop(backdrop: LayerBackdrop): Modifier =
+    this then LayerBackdropElement(backdrop)
+
+private class LayerBackdropElement(
+    val backdrop: LayerBackdrop,
+) : ModifierNodeElement<LayerBackdropNode>() {
+
+    override fun create(): LayerBackdropNode {
+        return LayerBackdropNode(backdrop)
+    }
+
+    override fun update(node: LayerBackdropNode) {
+        if (node.backdrop != backdrop) {
+            node.backdrop.layerCoordinates = null
+            node.backdrop = backdrop
+        }
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "layerBackdrop"
+        properties["backdrop"] = backdrop
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LayerBackdropElement) return false
+
+        if (backdrop != other.backdrop) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return backdrop.hashCode()
+    }
+}
+
+private class LayerBackdropNode(
+    var backdrop: LayerBackdrop,
+) : DrawModifierNode, GlobalPositionAwareModifierNode, Modifier.Node() {
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+        recordLayer(backdrop.graphicsLayer) { backdrop.onDraw(this@draw) }
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        if (coordinates.isAttached) {
+            backdrop.layerCoordinates = coordinates
+        }
+    }
+
+    override fun onDetach() {
+        backdrop.layerCoordinates = null
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/Blur.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/Blur.kt
@@ -1,0 +1,29 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects
+
+import androidx.annotation.FloatRange
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.TileMode
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropEffectScope
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRenderEffectSupported
+
+fun BackdropEffectScope.blur(
+    @FloatRange(from = 0.0) radius: Float,
+    edgeTreatment: TileMode = TileMode.Clamp,
+) {
+    if (!isRenderEffectSupported()) return
+    if (radius <= 0f) return
+
+    if (edgeTreatment != TileMode.Clamp || renderEffect != null) {
+        if (radius > padding) {
+            padding = radius
+        }
+    }
+
+    renderEffect =
+        BlurEffect(
+            renderEffect,
+            radius,
+            radius,
+            edgeTreatment
+        )
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/ColorFilter.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/ColorFilter.kt
@@ -1,0 +1,75 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects
+
+import androidx.annotation.FloatRange
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.ColorMatrixColorFilter
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropEffectScope
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.ColorFilterEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRenderEffectSupported
+
+fun BackdropEffectScope.colorFilter(colorFilter: ColorFilter) {
+    if (!isRenderEffectSupported()) return
+
+    renderEffect = ColorFilterEffect(renderEffect, colorFilter)
+}
+
+fun BackdropEffectScope.opacity(@FloatRange(from = 0.0, to = 1.0) alpha: Float) {
+    val colorMatrix = ColorMatrix(
+        floatArrayOf(
+            1f, 0f, 0f, 0f, 0f,
+            0f, 1f, 0f, 0f, 0f,
+            0f, 0f, 1f, 0f, 0f,
+            0f, 0f, 0f, alpha, 0f
+        )
+    )
+    colorFilter(ColorMatrixColorFilter(colorMatrix))
+}
+
+fun BackdropEffectScope.colorControls(
+    brightness: Float = 0f,
+    contrast: Float = 1f,
+    saturation: Float = 1f,
+) {
+    if (brightness == 0f && contrast == 1f && saturation == 1f) {
+        return
+    }
+
+    colorFilter(colorControlsColorFilter(brightness, contrast, saturation))
+}
+
+private val VibrantColorFilter = colorControlsColorFilter(saturation = 1.5f)
+
+fun BackdropEffectScope.vibrancy() {
+    colorFilter(VibrantColorFilter)
+}
+
+private fun colorControlsColorFilter(
+    brightness: Float = 0f,
+    contrast: Float = 1f,
+    saturation: Float = 1f,
+): ColorFilter {
+    val invSat = 1f - saturation
+    val r = 0.213f * invSat
+    val g = 0.715f * invSat
+    val b = 0.072f * invSat
+
+    val c = contrast
+    val t = (0.5f - c * 0.5f + brightness) * 255f
+    val s = saturation
+
+    val cr = c * r
+    val cg = c * g
+    val cb = c * b
+    val cs = c * s
+
+    val colorMatrix = ColorMatrix(
+        floatArrayOf(
+            cr + cs, cg, cb, 0f, t,
+            cr, cg + cs, cb, 0f, t,
+            cr, cg, cb + cs, 0f, t,
+            0f, 0f, 0f, 1f, 0f
+        )
+    )
+    return ColorMatrixColorFilter(colorMatrix)
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/Lens.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/Lens.kt
@@ -1,0 +1,146 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects
+
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastCoerceAtLeast
+import androidx.compose.ui.util.fastCoerceAtMost
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropEffectScope
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.RoundedRectRefractionShaderString
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.RoundedRectRefractionWithDispersionShaderString
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.RuntimeShaderEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRuntimeShaderSupported
+
+fun BackdropEffectScope.lens(
+    @FloatRange(from = 0.0) refractionHeight: Float,
+    @FloatRange(from = 0.0) refractionAmount: Float,
+    depthEffect: Boolean = false,
+    chromaticAberration: Boolean = false,
+) {
+    if (!isRuntimeShaderSupported()) return
+    if (refractionHeight <= 0f || refractionAmount <= 0f) return
+
+    if (padding > 0f) {
+        padding = (padding - refractionHeight).fastCoerceAtLeast(0f)
+    }
+
+    val cornerRadii = cornerRadii
+    val effect =
+        if (cornerRadii != null) {
+            val shader =
+                if (!chromaticAberration) {
+                    obtainRuntimeShader(
+                        "Refraction",
+                        RoundedRectRefractionShaderString
+                    )
+                } else {
+                    obtainRuntimeShader(
+                        "RefractionWithDispersion",
+                        RoundedRectRefractionWithDispersionShaderString
+                    )
+                }
+            shader.apply {
+                setFloatUniform("size", size.width, size.height)
+                setFloatUniform("offset", -padding, -padding)
+                setFloatUniform("cornerRadii", cornerRadii)
+                setFloatUniform("refractionHeight", refractionHeight)
+                setFloatUniform("refractionAmount", -refractionAmount)
+                setFloatUniform("depthEffect", if (depthEffect) 1f else 0f)
+                if (chromaticAberration) {
+                    setFloatUniform("chromaticAberration", 1f)
+                }
+            }
+            RuntimeShaderEffect(shader, "content")
+        } else {
+            throwUnsupportedSDFException()
+        }
+    effect(effect)
+}
+
+private val BackdropEffectScope.cornerRadii: FloatArray?
+    get() = when (val shape = shape) {
+        is RoundedRectangularShape -> {
+            val corners = shape.corners(size, layoutDirection, this)
+            floatArrayOf(
+                corners.topLeft,
+                corners.topRight,
+                corners.bottomRight,
+                corners.bottomLeft
+            )
+        }
+
+        is AbsoluteRoundedCornerShape -> {
+            val size = size
+            val maxRadius = size.minDimension / 2f
+            val topLeft = shape.topStart.toPx(size, this)
+            val topRight = shape.topEnd.toPx(size, this)
+            val bottomRight = shape.bottomEnd.toPx(size, this)
+            val bottomLeft = shape.bottomStart.toPx(size, this)
+            floatArrayOf(
+                topLeft.fastCoerceAtMost(maxRadius),
+                topRight.fastCoerceAtMost(maxRadius),
+                bottomRight.fastCoerceAtMost(maxRadius),
+                bottomLeft.fastCoerceAtMost(maxRadius)
+            )
+        }
+
+        is CornerBasedShape -> {
+            val size = size
+            val maxRadius = size.minDimension / 2f
+            val isLtr = layoutDirection == LayoutDirection.Ltr
+            val topLeft =
+                if (isLtr) shape.topStart.toPx(size, this)
+                else shape.topEnd.toPx(size, this)
+            val topRight =
+                if (isLtr) shape.topEnd.toPx(size, this)
+                else shape.topStart.toPx(size, this)
+            val bottomRight =
+                if (isLtr) shape.bottomEnd.toPx(size, this)
+                else shape.bottomStart.toPx(size, this)
+            val bottomLeft =
+                if (isLtr) shape.bottomStart.toPx(size, this)
+                else shape.bottomEnd.toPx(size, this)
+            floatArrayOf(
+                topLeft.fastCoerceAtMost(maxRadius),
+                topRight.fastCoerceAtMost(maxRadius),
+                bottomRight.fastCoerceAtMost(maxRadius),
+                bottomLeft.fastCoerceAtMost(maxRadius)
+            )
+        }
+
+        else -> null
+    }
+
+private fun throwUnsupportedSDFException(): Nothing {
+    throw UnsupportedOperationException(
+        "Only RoundedRectangularShape or CornerBasedShape is supported in lens effects."
+    )
+}
+
+@Immutable
+sealed interface RoundedRectangularShape : Shape {
+
+    val style: RoundedCornerStyle?
+        get() = null
+
+    fun corners(size: Size, layoutDirection: LayoutDirection, density: Density): Corners
+
+    fun copy(style: RoundedCornerStyle): RoundedRectangularShape
+
+    data class Corners(
+        val topLeft: Float,
+        val topRight: Float,
+        val bottomRight: Float,
+        val bottomLeft: Float,
+    )
+}
+
+enum class RoundedCornerStyle {
+    Circular,
+    Continuous
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/RenderEffect.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/effects/RenderEffect.kt
@@ -1,0 +1,34 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.effects
+
+import androidx.compose.ui.graphics.RenderEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropEffectScope
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.RuntimeShaderEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.chain
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRenderEffectSupported
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRuntimeShaderSupported
+import org.intellij.lang.annotations.Language
+import kotlin.contracts.ExperimentalContracts
+
+fun BackdropEffectScope.effect(effect: RenderEffect) {
+    if (!isRenderEffectSupported()) return
+
+    renderEffect = renderEffect.chain(effect)
+}
+
+@OptIn(ExperimentalContracts::class)
+fun BackdropEffectScope.runtimeShaderEffect(
+    key: String,
+    @Language("AGSL") shaderString: String,
+    uniformShaderName: String,
+    block: BackdropRuntimeShader.() -> Unit,
+) {
+    if (!isRuntimeShaderSupported()) return
+
+    val effect =
+        RuntimeShaderEffect(
+            runtimeShader = obtainRuntimeShader(key, shaderString).apply(block),
+            uniformShaderName = uniformShaderName
+        )
+    renderEffect = renderEffect.chain(effect)
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/Highlight.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/Highlight.kt
@@ -1,0 +1,28 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight
+
+import androidx.annotation.FloatRange
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class Highlight(
+    val width: Dp = 0.5f.dp,
+    val blurRadius: Dp = width / 2f,
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val style: HighlightStyle = HighlightStyle.Default,
+) {
+
+    companion object {
+
+        @Stable
+        val Default: Highlight = Highlight()
+
+        @Stable
+        val Ambient: Highlight = Highlight(style = HighlightStyle.Ambient)
+
+        @Stable
+        val Plain: Highlight = Highlight(style = HighlightStyle.Plain)
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/HighlightModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/HighlightModifier.kt
@@ -1,0 +1,166 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.fastCoerceAtMost
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShaderCacheImpl
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.ShapeProvider
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.blur
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.clipOutline
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.setRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRuntimeShaderSupported
+import kotlin.math.ceil
+
+internal class HighlightElement(
+    val shapeProvider: ShapeProvider,
+    val highlight: () -> Highlight?,
+) : ModifierNodeElement<HighlightNode>() {
+
+    override fun create(): HighlightNode {
+        return HighlightNode(shapeProvider, highlight)
+    }
+
+    override fun update(node: HighlightNode) {
+        node.shapeProvider = shapeProvider
+        node.highlight = highlight
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "highlight"
+        properties["shapeProvider"] = shapeProvider
+        properties["highlight"] = highlight
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HighlightElement) return false
+
+        if (shapeProvider != other.shapeProvider) return false
+        if (highlight != other.highlight) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = shapeProvider.hashCode()
+        result = 31 * result + highlight.hashCode()
+        return result
+    }
+}
+
+internal class HighlightNode(
+    var shapeProvider: ShapeProvider,
+    var highlight: () -> Highlight?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var highlightLayer: GraphicsLayer? = null
+
+    private val paint =
+        Paint().apply {
+            style = PaintingStyle.Stroke
+        }
+    private var clipPath: Path? = null
+
+    private val runtimeShaderCache = BackdropRuntimeShaderCacheImpl()
+
+    private var prevStyle: HighlightStyle? = null
+
+    override fun ContentDrawScope.draw() {
+        val highlight = highlight()
+        if (highlight == null || highlight.width.value <= 0f) {
+            return drawContent()
+        }
+
+        drawContent()
+
+        val highlightLayer = highlightLayer
+        if (highlightLayer != null) {
+            val size = size
+            val density: Density = this
+            val layoutDirection = layoutDirection
+
+            val safeSize =
+                IntSize(
+                    ceil(size.width).toInt() + 2,
+                    ceil(size.height).toInt() + 2
+                )
+
+            val outline = shapeProvider.shape.createOutline(size, layoutDirection, density)
+            val clipPath =
+                if (outline is Outline.Rounded) {
+                    clipPath ?: Path().also { clipPath = it }
+                } else {
+                    null
+                }
+
+            configurePaint(highlight)
+
+            highlightLayer.alpha = highlight.alpha
+            highlightLayer.blendMode = highlight.style.blendMode
+            highlightLayer.record(safeSize) {
+                translate(1f, 1f) {
+                    val canvas = drawContext.canvas
+                    canvas.save()
+                    canvas.clipOutline(outline, clipPath)
+                    canvas.drawOutline(outline, paint)
+                    canvas.restore()
+                }
+            }
+
+            translate(-1f, -1f) {
+                drawLayer(highlightLayer)
+            }
+        }
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        highlightLayer = graphicsContext.createGraphicsLayer()
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        highlightLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            highlightLayer = null
+        }
+        clipPath = null
+        runtimeShaderCache.clear()
+        prevStyle = null
+    }
+
+    private fun DrawScope.configurePaint(highlight: Highlight) {
+        paint.color = highlight.style.color
+        paint.strokeWidth = ceil(highlight.width.toPx().fastCoerceAtMost(size.minDimension / 2f)) * 2f
+        paint.blur(highlight.blurRadius.toPx())
+        if (isRuntimeShaderSupported()) {
+            val shader =
+                with(highlight.style) {
+                    createShader(
+                        shape = shapeProvider.shape,
+                        runtimeShaderCache = runtimeShaderCache
+                    )
+                }
+            paint.setRuntimeShader(shader)
+        }
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/HighlightStyle.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/highlight/HighlightStyle.kt
@@ -1,0 +1,138 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.highlight
+
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastCoerceAtMost
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShaderCache
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.AmbientHighlightShaderString
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.DefaultHighlightShaderString
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRuntimeShaderSupported
+import kotlin.math.PI
+
+@Immutable
+interface HighlightStyle {
+
+    val color: Color
+
+    val blendMode: BlendMode
+
+    fun DrawScope.createShader(
+        shape: Shape,
+        runtimeShaderCache: BackdropRuntimeShaderCache,
+    ): BackdropRuntimeShader?
+
+    @Immutable
+    data class Plain(
+        override val color: Color = Color.White.copy(alpha = 0.38f),
+        override val blendMode: BlendMode = BlendMode.Plus,
+    ) : HighlightStyle {
+
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: BackdropRuntimeShaderCache,
+        ): BackdropRuntimeShader? = null
+    }
+
+    @Immutable
+    data class Default(
+        override val color: Color = Color.White.copy(alpha = 0.5f),
+        override val blendMode: BlendMode = BlendMode.Plus,
+        val angle: Float = 45f,
+        @param:FloatRange(from = 0.0) val falloff: Float = 1f,
+    ) : HighlightStyle {
+
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: BackdropRuntimeShaderCache,
+        ): BackdropRuntimeShader? {
+            return if (isRuntimeShaderSupported()) {
+                runtimeShaderCache.obtainRuntimeShader(
+                    "Default",
+                    DefaultHighlightShaderString
+                ).apply {
+                    setFloatUniform("size", size.width, size.height)
+                    setFloatUniform("cornerRadii", getCornerRadii(shape))
+                    setColorUniform("color", color.copy(alpha = 1f))
+                    setFloatUniform("angle", angle * (PI / 180f).toFloat())
+                    setFloatUniform("falloff", falloff)
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    @Immutable
+    data class Ambient(
+        @param:FloatRange(from = 0.0, to = 1.0) val intensity: Float = 0.38f,
+    ) : HighlightStyle {
+
+        override val color: Color = Color.White.copy(alpha = intensity)
+
+        override val blendMode: BlendMode = DrawScope.DefaultBlendMode
+
+        override fun DrawScope.createShader(
+            shape: Shape,
+            runtimeShaderCache: BackdropRuntimeShaderCache,
+        ): BackdropRuntimeShader? {
+            return if (isRuntimeShaderSupported()) {
+                runtimeShaderCache.obtainRuntimeShader(
+                    "Ambient",
+                    AmbientHighlightShaderString
+                ).apply {
+                    setFloatUniform("size", size.width, size.height)
+                    setFloatUniform("cornerRadii", getCornerRadii(shape))
+                    setFloatUniform("angle", 45f * (PI / 180f).toFloat())
+                    setFloatUniform("falloff", 1f)
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    companion object {
+
+        @Stable
+        val Default: Default = Default()
+
+        @Stable
+        val Ambient: Ambient = Ambient()
+
+        @Stable
+        val Plain: Plain = Plain()
+    }
+}
+
+private fun DrawScope.getCornerRadii(shape: Shape): FloatArray {
+    val size = size
+    val maxRadius = size.minDimension / 2f
+    val shape = shape as? CornerBasedShape ?: return FloatArray(4) { maxRadius }
+    val isLtr = layoutDirection == LayoutDirection.Ltr
+    val topLeft =
+        if (isLtr) shape.topStart.toPx(size, this)
+        else shape.topEnd.toPx(size, this)
+    val topRight =
+        if (isLtr) shape.topEnd.toPx(size, this)
+        else shape.topStart.toPx(size, this)
+    val bottomRight =
+        if (isLtr) shape.bottomEnd.toPx(size, this)
+        else shape.bottomStart.toPx(size, this)
+    val bottomLeft =
+        if (isLtr) shape.bottomStart.toPx(size, this)
+        else shape.bottomEnd.toPx(size, this)
+    return floatArrayOf(
+        topLeft.fastCoerceAtMost(maxRadius),
+        topRight.fastCoerceAtMost(maxRadius),
+        bottomRight.fastCoerceAtMost(maxRadius),
+        bottomLeft.fastCoerceAtMost(maxRadius)
+    )
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropOutline.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropOutline.kt
@@ -1,0 +1,18 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+
+internal fun Canvas.clipOutline(outline: Outline, path: Path?) {
+    when (outline) {
+        is Outline.Rectangle -> clipRect(outline.rect)
+        is Outline.Rounded -> {
+            path!!.rewind()
+            path.addRoundRect(outline.roundRect)
+            clipPath(path)
+        }
+
+        is Outline.Generic -> clipPath(outline.path)
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.kt
@@ -1,0 +1,8 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.Paint
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+
+internal expect fun Paint.blur(radius: Float)
+
+internal expect fun Paint.setRuntimeShader(runtimeShader: BackdropRuntimeShader?)

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.kt
@@ -1,0 +1,17 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.RenderEffect
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+
+internal expect fun RenderEffect?.chain(other: RenderEffect): RenderEffect
+
+internal expect fun RuntimeShaderEffect(
+    runtimeShader: BackdropRuntimeShader,
+    uniformShaderName: String,
+): RenderEffect
+
+internal expect fun ColorFilterEffect(
+    renderEffect: RenderEffect? = null,
+    colorFilter: ColorFilter,
+): RenderEffect

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropShaders.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropShaders.kt
@@ -1,0 +1,188 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import org.intellij.lang.annotations.Language
+
+@Language("AGSL")
+private const val RoundedRectSDF = """
+float radiusAt(float2 coord, float4 radii) {
+    if (coord.x >= 0.0) {
+        if (coord.y <= 0.0) return radii.y;
+        else return radii.z;
+    } else {
+        if (coord.y <= 0.0) return radii.x;
+        else return radii.w;
+    }
+}
+
+float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    float outside = length(max(cornerCoord, 0.0)) - radius;
+    float inside = min(max(cornerCoord.x, cornerCoord.y), 0.0);
+    return outside + inside;
+}
+
+float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
+        return sign(coord) * normalize(max(cornerCoord, 0.0));
+    } else {
+        float gradX = step(cornerCoord.y, cornerCoord.x);
+        return sign(coord) * float2(gradX, 1.0 - gradX);
+    }
+}"""
+
+@Language("AGSL")
+internal const val RoundedRectRefractionShaderString = """
+uniform shader content;
+
+uniform float2 size;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+
+$RoundedRectSDF
+
+float circleMap(float x) {
+    return 1.0 - sqrt(1.0 - x * x);
+}
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) {
+        return content.eval(coord);
+    }
+    sd = min(sd, 0.0);
+    
+    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    
+    float2 refractedCoord = coord + d * grad;
+    return content.eval(refractedCoord);
+}"""
+
+@Language("AGSL")
+internal val RoundedRectRefractionWithDispersionShaderString = """
+uniform shader content;
+
+uniform float2 size;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+uniform float chromaticAberration;
+
+$RoundedRectSDF
+
+float circleMap(float x) {
+    return 1.0 - sqrt(1.0 - x * x);
+}
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) {
+        return content.eval(coord);
+    }
+    sd = min(sd, 0.0);
+    
+    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    
+    float2 refractedCoord = coord + d * grad;
+    float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
+    float2 dispersedCoord = d * grad * dispersionIntensity;
+    
+    half4 color = half4(0.0);
+    
+    half4 red = content.eval(refractedCoord + dispersedCoord);
+    color.r += red.r / 3.5;
+    color.a += red.a / 7.0;
+    
+    half4 orange = content.eval(refractedCoord + dispersedCoord * (2.0 / 3.0));
+    color.r += orange.r / 3.5;
+    color.g += orange.g / 7.0;
+    color.a += orange.a / 7.0;
+    
+    half4 yellow = content.eval(refractedCoord + dispersedCoord * (1.0 / 3.0));
+    color.r += yellow.r / 3.5;
+    color.g += yellow.g / 3.5;
+    color.a += yellow.a / 7.0;
+    
+    half4 green = content.eval(refractedCoord);
+    color.g += green.g / 3.5;
+    color.a += green.a / 7.0;
+    
+    half4 cyan = content.eval(refractedCoord - dispersedCoord * (1.0 / 3.0));
+    color.g += cyan.g / 3.5;
+    color.b += cyan.b / 3.0;
+    color.a += cyan.a / 7.0;
+    
+    half4 blue = content.eval(refractedCoord - dispersedCoord * (2.0 / 3.0));
+    color.b += blue.b / 3.0;
+    color.a += blue.a / 7.0;
+    
+    half4 purple = content.eval(refractedCoord - dispersedCoord);
+    color.r += purple.r / 7.0;
+    color.b += purple.b / 3.0;
+    color.a += purple.a / 7.0;
+    
+    return color;
+}"""
+
+@Language("AGSL")
+internal const val DefaultHighlightShaderString = """
+uniform float2 size;
+uniform float4 cornerRadii;
+layout(color) uniform half4 color;
+uniform float angle;
+uniform float falloff;
+
+$RoundedRectSDF
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = coord - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
+    float2 normal = float2(cos(angle), sin(angle));
+    float d = dot(grad, normal);
+    float intensity = pow(abs(d), falloff);
+    return color * intensity;
+}"""
+
+@Language("AGSL")
+internal const val AmbientHighlightShaderString = """
+uniform float2 size;
+uniform float4 cornerRadii;
+uniform float angle;
+uniform float falloff;
+
+$RoundedRectSDF
+
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = coord - halfSize;
+    float radius = radiusAt(coord, cornerRadii);
+    
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
+    float2 normal = float2(cos(angle), sin(angle));
+    float d = dot(grad, normal);
+    float intensity = pow(abs(d), falloff);
+    float t = step(0.0, d);
+    return half4(t, t, t, 1.0) * intensity;
+}"""

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/InverseLayerScope.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/InverseLayerScope.kt
@@ -1,0 +1,130 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.DefaultCameraDistance
+import androidx.compose.ui.graphics.DefaultShadowColor
+import androidx.compose.ui.graphics.GraphicsLayerScope
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.drawscope.DrawTransform
+import androidx.compose.ui.unit.Density
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal class InverseLayerScope : GraphicsLayerScope {
+
+    override var size: Size = Size.Unspecified
+    override var density: Float = 1f
+    override var fontScale: Float = 1f
+
+    override var scaleX: Float = 1f
+    override var scaleY: Float = 1f
+    override var alpha: Float = 0f
+    override var translationX: Float = 0f
+    override var translationY: Float = 0f
+    override var shadowElevation: Float = 0f
+    override var ambientShadowColor: Color = DefaultShadowColor
+    override var spotShadowColor: Color = DefaultShadowColor
+    override var rotationX: Float = 0f
+    override var rotationY: Float = 0f
+    override var rotationZ: Float = 0f
+    override var cameraDistance: Float = DefaultCameraDistance
+    override var transformOrigin: TransformOrigin = TransformOrigin.Center
+    override var shape: Shape = RectangleShape
+    override var clip: Boolean = false
+    override var renderEffect: RenderEffect? = null
+    override var blendMode: BlendMode = BlendMode.SrcOver
+    override var colorFilter: ColorFilter? = null
+    override var compositingStrategy: CompositingStrategy = CompositingStrategy.Auto
+
+    private var matrix: Matrix? = null
+
+    fun DrawTransform.inverseTransform(
+        density: Density,
+        layerBlock: GraphicsLayerScope.() -> Unit,
+    ) {
+        this@InverseLayerScope.size = size
+        this@InverseLayerScope.density = density.density
+        fontScale = density.fontScale
+
+        layerBlock()
+
+        inverseTransformAtTopLeft(
+            rotationZ = rotationZ,
+            scaleX = scaleX,
+            scaleY = scaleY
+        )
+    }
+
+    fun reset() {
+        size = Size.Unspecified
+        density = 1f
+        fontScale = 1f
+
+        scaleX = 1f
+        scaleY = 1f
+        alpha = 1f
+        translationX = 0f
+        translationY = 0f
+        shadowElevation = 0f
+        ambientShadowColor = DefaultShadowColor
+        spotShadowColor = DefaultShadowColor
+        rotationX = 0f
+        rotationY = 0f
+        rotationZ = 0f
+        cameraDistance = DefaultCameraDistance
+        transformOrigin = TransformOrigin.Center
+        shape = RectangleShape
+        clip = false
+        renderEffect = null
+        blendMode = BlendMode.SrcOver
+        colorFilter = null
+        compositingStrategy = CompositingStrategy.Auto
+
+        matrix = null
+    }
+
+    private fun DrawTransform.inverseTransformAtTopLeft(
+        rotationZ: Float = 0f,
+        scaleX: Float = 1f,
+        scaleY: Float = 1f,
+    ) {
+        if (rotationZ == 0f) {
+            if (scaleX != 0f && scaleY != 0f) {
+                scale(1f / scaleX, 1f / scaleY, Offset.Zero)
+            }
+            return
+        }
+
+        val matrix = matrix ?: Matrix().also { matrix = it }
+        if (matrix.values.size < 16) return
+
+        val rz = rotationZ * (PI / 180.0)
+        val rsz = sin(rz).toFloat()
+        val rcz = cos(rz).toFloat()
+
+        val a00 = rcz * scaleX
+        val a01 = rsz * scaleY
+        val a10 = -rsz * scaleX
+        val a11 = rcz * scaleY
+
+        val det = a00 * a11 - a01 * a10
+        if (det == 0f) return
+        val invDet = 1f / det
+        matrix[0, 0] = a11 * invDet
+        matrix[0, 1] = -a01 * invDet
+        matrix[1, 0] = -a10 * invDet
+        matrix[1, 1] = a00 * invDet
+
+        transform(matrix)
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/LayerRecorder.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/LayerRecorder.kt
@@ -1,0 +1,26 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.requireDensity
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toIntSize
+
+context(node: DelegatableNode)
+internal fun DrawScope.recordLayer(
+    layer: GraphicsLayer,
+    size: IntSize = this.size.toIntSize(),
+    block: DrawScope.() -> Unit,
+) {
+    val density = node.requireDensity()
+    layer.record(size) {
+        val prevDensity = drawContext.density
+        drawContext.density = density
+        try {
+            this.block()
+        } finally {
+            drawContext.density = prevDensity
+        }
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/ShapeProvider.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/ShapeProvider.kt
@@ -1,0 +1,44 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+
+@Immutable
+internal class ShapeProvider(val shapeBlock: () -> Shape) {
+
+    private var _shape: Shape? = null
+    private var _outline: Outline? = null
+    private var _size: Size = Size.Unspecified
+    private var _layoutDirection: LayoutDirection? = null
+    private var _density: Float? = null
+
+    val innerShape
+        get() = shapeBlock()
+
+    val shape = object : Shape {
+
+        override fun createOutline(
+            size: Size,
+            layoutDirection: LayoutDirection,
+            density: Density,
+        ): Outline {
+            val shape = shapeBlock()
+            if (_shape != shape) {
+                _shape = shape
+                _outline = null
+            }
+            if (_outline == null || _size != size || _layoutDirection != layoutDirection || _density != density.density) {
+                _size = size
+                _layoutDirection = layoutDirection
+                _density = density.density
+                _outline = shape.createOutline(size, layoutDirection, density)
+            }
+
+            return _outline!!
+        }
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/InnerShadow.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/InnerShadow.kt
@@ -1,0 +1,41 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow
+
+import androidx.annotation.FloatRange
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.util.lerp
+
+@Immutable
+data class InnerShadow(
+    val radius: Dp = 24f.dp,
+    val offset: DpOffset = DpOffset(0f.dp, radius),
+    val color: Color = Color.Black.copy(alpha = 0.15f),
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val blendMode: BlendMode = DrawScope.DefaultBlendMode,
+) {
+
+    companion object {
+
+        @Stable
+        val Default: InnerShadow = InnerShadow()
+    }
+}
+
+@Stable
+fun lerp(start: InnerShadow, stop: InnerShadow, fraction: Float): InnerShadow {
+    return InnerShadow(
+        radius = lerp(start.radius, stop.radius, fraction),
+        offset = lerp(start.offset, stop.offset, fraction),
+        color = lerp(start.color, stop.color, fraction),
+        alpha = lerp(start.alpha, stop.alpha, fraction),
+        blendMode = if (fraction < 0.5f) start.blendMode else stop.blendMode
+    )
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/InnerShadowModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/InnerShadowModifier.kt
@@ -1,0 +1,158 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.CompositingStrategy
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.ShapeProvider
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.clipOutline
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.isRenderEffectSupported
+
+internal class InnerShadowElement(
+    val shapeProvider: ShapeProvider,
+    val shadow: () -> InnerShadow?,
+) : ModifierNodeElement<InnerShadowNode>() {
+
+    override fun create(): InnerShadowNode {
+        return InnerShadowNode(shapeProvider, shadow)
+    }
+
+    override fun update(node: InnerShadowNode) {
+        node.shapeProvider = shapeProvider
+        node.shadow = shadow
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "innerShadow"
+        properties["shapeProvider"] = shapeProvider
+        properties["shadow"] = shadow
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InnerShadowElement) return false
+
+        if (shapeProvider != other.shapeProvider) return false
+        if (shadow != other.shadow) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = shapeProvider.hashCode()
+        result = 31 * result + shadow.hashCode()
+        return result
+    }
+}
+
+internal class InnerShadowNode(
+    var shapeProvider: ShapeProvider,
+    var shadow: () -> InnerShadow?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var shadowLayer: GraphicsLayer? = null
+
+    private val paint = Paint()
+    private var clipPath: Path? = null
+
+    private var prevRadius = Float.NaN
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+
+        if (!isRenderEffectSupported()) return
+
+        val shadow = shadow() ?: return
+
+        val shadowLayer = shadowLayer
+        if (shadowLayer != null) {
+            val size = size
+            val density: Density = this
+            val layoutDirection = layoutDirection
+
+            val radius = shadow.radius.toPx()
+            val offsetX = shadow.offset.x.toPx()
+            val offsetY = shadow.offset.y.toPx()
+
+            val outline = shapeProvider.shape.createOutline(size, layoutDirection, density)
+            val clipPath =
+                if (outline is Outline.Rounded) {
+                    clipPath ?: Path().also { clipPath = it }
+                } else {
+                    null
+                }
+
+            configurePaint(shadow)
+
+            shadowLayer.alpha = shadow.alpha
+            shadowLayer.blendMode = shadow.blendMode
+            if (prevRadius != radius) {
+                shadowLayer.renderEffect =
+                    if (radius > 0f) {
+                        BlurEffect(radius, radius, TileMode.Decal)
+                    } else {
+                        null
+                    }
+                prevRadius = radius
+            }
+            shadowLayer.record {
+                val canvas = drawContext.canvas
+                canvas.save()
+                canvas.clipOutline(outline, clipPath)
+                canvas.drawOutline(outline, paint)
+                canvas.translate(offsetX, offsetY)
+                canvas.drawOutline(outline, ShadowMaskPaint)
+                canvas.translate(-offsetX, -offsetY)
+                canvas.restore()
+            }
+
+            val canvas = drawContext.canvas
+            canvas.save()
+            canvas.clipOutline(outline, clipPath)
+            drawLayer(shadowLayer)
+            canvas.restore()
+        }
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer =
+            graphicsContext.createGraphicsLayer().apply {
+                compositingStrategy = CompositingStrategy.Offscreen
+            }
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            shadowLayer = null
+        }
+    }
+
+    private fun DrawScope.configurePaint(shadow: InnerShadow) {
+        paint.color = shadow.color
+    }
+}
+
+private val ShadowMaskPaint = Paint().apply {
+    blendMode = BlendMode.Clear
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/Shadow.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/Shadow.kt
@@ -1,0 +1,27 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow
+
+import androidx.annotation.FloatRange
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class Shadow(
+    val radius: Dp = 24f.dp,
+    val offset: DpOffset = DpOffset(0f.dp, radius / 6f),
+    val color: Color = Color.Black.copy(alpha = 0.1f),
+    @param:FloatRange(from = 0.0, to = 1.0) val alpha: Float = 1f,
+    val blendMode: BlendMode = DrawScope.DefaultBlendMode,
+) {
+
+    companion object {
+
+        @Stable
+        val Default: Shadow = Shadow()
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/ShadowModifier.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/shadow/ShadowModifier.kt
@@ -1,0 +1,137 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.shadow
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.CompositingStrategy
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.ShapeProvider
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal.blur
+import kotlin.math.ceil
+
+internal class ShadowElement(
+    val shapeProvider: ShapeProvider,
+    val shadow: () -> Shadow?,
+) : ModifierNodeElement<ShadowNode>() {
+
+    override fun create(): ShadowNode {
+        return ShadowNode(shapeProvider, shadow)
+    }
+
+    override fun update(node: ShadowNode) {
+        node.shapeProvider = shapeProvider
+        node.shadow = shadow
+        node.invalidateDraw()
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "shadow"
+        properties["shapeProvider"] = shapeProvider
+        properties["shadow"] = shadow
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ShadowElement) return false
+
+        if (shapeProvider != other.shapeProvider) return false
+        if (shadow != other.shadow) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = shapeProvider.hashCode()
+        result = 31 * result + shadow.hashCode()
+        return result
+    }
+}
+
+internal class ShadowNode(
+    var shapeProvider: ShapeProvider,
+    var shadow: () -> Shadow?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    private var shadowLayer: GraphicsLayer? = null
+
+    private val paint = Paint()
+
+    override fun ContentDrawScope.draw() {
+        val shadow = shadow() ?: return drawContent()
+
+        val shadowLayer = shadowLayer
+        if (shadowLayer != null) {
+            val size = size
+            val density: Density = this
+            val layoutDirection = layoutDirection
+
+            val radius = shadow.radius.toPx()
+            val offsetX = shadow.offset.x.toPx()
+            val offsetY = shadow.offset.y.toPx()
+            val shadowSize = IntSize(
+                ceil(size.width + radius * 4f + offsetX).toInt(),
+                ceil(size.height + radius * 4f + offsetY).toInt()
+            )
+            val outline = shapeProvider.shape.createOutline(size, layoutDirection, density)
+
+            configurePaint(shadow)
+
+            shadowLayer.alpha = shadow.alpha
+            shadowLayer.blendMode = shadow.blendMode
+            shadowLayer.record(shadowSize) {
+                translate(radius * 2f + offsetX, radius * 2f + offsetY) {
+                    val canvas = drawContext.canvas
+                    canvas.drawOutline(outline, paint)
+                    canvas.translate(-offsetX, -offsetY)
+                    canvas.drawOutline(outline, ShadowMaskPaint)
+                    canvas.translate(offsetX, offsetY)
+                }
+            }
+
+            translate(-radius * 2f, -radius * 2f) {
+                drawLayer(shadowLayer)
+            }
+        }
+
+        drawContent()
+    }
+
+    override fun onAttach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer =
+            graphicsContext.createGraphicsLayer().apply {
+                compositingStrategy = CompositingStrategy.Offscreen
+            }
+    }
+
+    override fun onDetach() {
+        val graphicsContext = requireGraphicsContext()
+        shadowLayer?.let { layer ->
+            graphicsContext.releaseGraphicsLayer(layer)
+            shadowLayer = null
+        }
+    }
+
+    private fun DrawScope.configurePaint(shadow: Shadow) {
+        paint.color = shadow.color
+        paint.blur(shadow.radius.toPx())
+    }
+}
+
+private val ShadowMaskPaint = Paint().apply {
+    blendMode = BlendMode.Clear
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/BlurSettingsScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/BlurSettingsScreen.kt
@@ -315,8 +315,8 @@ private fun ColumnScope.LiquidGlassOptions(
             Slider(
                 value = blurAmount,
                 onValueChange = { blurAmount = it },
-                valueRange = 1f..10f,
-                steps = 10
+                valueRange = 0f..10f,
+                steps = 11
             )
         },
         colors = colors,

--- a/kmpuiviews/src/jvmMain/kotlin/com/programmersbox/kmpuiviews/di/AppModule.jvm.kt
+++ b/kmpuiviews/src/jvmMain/kotlin/com/programmersbox/kmpuiviews/di/AppModule.jvm.kt
@@ -7,6 +7,7 @@ import com.programmersbox.datastore.PlatformDataStoreHandling
 import com.programmersbox.datastore.SettingsSerializer
 import com.programmersbox.datastore.createProtobuf
 import com.programmersbox.kmpextensionloader.SourceLoader
+import com.programmersbox.kmpuiviews.AboutLibraryBuilder
 import com.programmersbox.kmpuiviews.DateTimeFormatHandler
 import com.programmersbox.kmpuiviews.IconLoader
 import com.programmersbox.kmpuiviews.KmpGenericInfo
@@ -43,6 +44,7 @@ actual fun platformModule(): Module = module {
     factory<TranslationHandler> { TranslationItemHandler() }
     factory<TranslationModelHandler> { TranslationModelHandlerImpl() }
     singleOf(::TrayState)
+    singleOf(::AboutLibraryBuilder)
 
     single {
         AppDirs {

--- a/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.skiko.kt
+++ b/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropPlatform.skiko.kt
@@ -1,0 +1,5 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+actual fun isRenderEffectSupported(): Boolean = true
+
+actual fun isRuntimeShaderSupported(): Boolean = true

--- a/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.skiko.kt
+++ b/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/BackdropRuntimeShader.skiko.kt
@@ -1,0 +1,71 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.asComposeShader
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
+import org.intellij.lang.annotations.Language
+import org.jetbrains.skia.RuntimeEffect
+import org.jetbrains.skia.RuntimeShaderBuilder
+
+actual fun BackdropRuntimeShader(@Language("AGSL") shaderString: String): BackdropRuntimeShader {
+    val shader = RuntimeShaderBuilder(RuntimeEffect.makeForShader(shaderString))
+    return SkikoRuntimeShader(shader)
+}
+
+actual fun BackdropRuntimeShader.asComposeShader(): Shader {
+    return this.asSkikoRuntimeShader().makeShader().asComposeShader()
+}
+
+fun BackdropRuntimeShader.asSkikoRuntimeShader(): RuntimeShaderBuilder {
+    return (this as SkikoRuntimeShader).shader
+}
+
+internal class SkikoRuntimeShader(val shader: RuntimeShaderBuilder) : BackdropRuntimeShader {
+
+    override fun setFloatUniform(name: String, value: Float) {
+        shader.uniform(name, value)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float) {
+        shader.uniform(name, value1, value2)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float) {
+        shader.uniform(name, value1, value2, value3)
+    }
+
+    override fun setFloatUniform(name: String, value1: Float, value2: Float, value3: Float, value4: Float) {
+        shader.uniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setFloatUniform(name: String, values: FloatArray) {
+        shader.uniform(name, values)
+    }
+
+    override fun setIntUniform(name: String, value: Int) {
+        shader.uniform(name, value)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int) {
+        shader.uniform(name, value1, value2)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int) {
+        shader.uniform(name, value1, value2, value3)
+    }
+
+    override fun setIntUniform(name: String, value1: Int, value2: Int, value3: Int, value4: Int) {
+        shader.uniform(name, value1, value2, value3, value4)
+    }
+
+    override fun setIntUniform(name: String, values: IntArray) {
+        throw UnsupportedOperationException("Setting int array uniforms is not supported on Skia RuntimeShader.")
+    }
+
+    override fun setColorUniform(name: String, color: Color) {
+        val srgb = color.convert(ColorSpaces.Srgb)
+        val a = srgb.alpha
+        shader.uniform(name, srgb.red * a, srgb.green * a, srgb.blue * a, a)
+    }
+}

--- a/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.skiko.kt
+++ b/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropPaint.skiko.kt
@@ -1,0 +1,18 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.skiaPaint
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.asSkikoRuntimeShader
+import org.jetbrains.skia.FilterBlurMode
+import org.jetbrains.skia.MaskFilter
+
+internal actual fun Paint.blur(radius: Float) {
+    this.skiaPaint.maskFilter =
+        if (radius > 0f) MaskFilter.makeBlur(FilterBlurMode.NORMAL, radius)
+        else null
+}
+
+internal actual fun Paint.setRuntimeShader(runtimeShader: BackdropRuntimeShader?) {
+    this.skiaPaint.shader = runtimeShader?.asSkikoRuntimeShader()?.makeShader()
+}

--- a/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.skiko.kt
+++ b/kmpuiviews/src/skikoMain/kotlin/com/programmersbox/kmpuiviews/presentation/components/custombackdrop/internal/BackdropRenderEffect.skiko.kt
@@ -1,0 +1,40 @@
+package com.programmersbox.kmpuiviews.presentation.components.custombackdrop.internal
+
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.asSkiaColorFilter
+import androidx.compose.ui.graphics.skiaImageFilter
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.BackdropRuntimeShader
+import com.programmersbox.kmpuiviews.presentation.components.custombackdrop.asSkikoRuntimeShader
+import org.jetbrains.skia.ImageFilter
+
+internal actual fun RenderEffect?.chain(other: RenderEffect): RenderEffect {
+    return if (this != null) {
+        ImageFilter.makeCompose(other.skiaImageFilter, this.skiaImageFilter).asComposeRenderEffect()
+    } else {
+        other
+    }
+}
+
+internal actual fun RuntimeShaderEffect(
+    runtimeShader: BackdropRuntimeShader,
+    uniformShaderName: String,
+): RenderEffect {
+    return ImageFilter.makeRuntimeShader(
+        runtimeShader.asSkikoRuntimeShader(),
+        uniformShaderName,
+        null
+    ).asComposeRenderEffect()
+}
+
+internal actual fun ColorFilterEffect(
+    renderEffect: RenderEffect?,
+    colorFilter: ColorFilter,
+): RenderEffect {
+    return ImageFilter.makeColorFilter(
+        colorFilter.asSkiaColorFilter(),
+        renderEffect?.skiaImageFilter,
+        null
+    ).asComposeRenderEffect()
+}


### PR DESCRIPTION
…dependency

- **Custom Backdrop Implementation**: Introduced a comprehensive internal system for backdrop effects, including `LayerBackdrop`, `BackdropEffectScope`, and support for `RenderEffect` chaining.
- **Shader Support**:
    - Added AGSL-based shaders for rounded rectangle refraction, chromatic aberration (dispersion), and highlights.
    - Implemented platform-specific `BackdropRuntimeShader` for Android and Skiko (JVM/iOS) targets.
- **Visual Enhancements**:
    - Introduced `InnerShadow`, `Shadow`, and `Highlight` modifiers with customizable styles (Ambient, Plain, Default).
    - Added support for color filters, vibrancy, and opacity effects within the backdrop scope.
- **Refactoring**:
    - Migrated `BlurKindLiquidGlass` and `BlurKindModifier` to use the new internal `custombackdrop` package.
    - Commented out the external `backdrop` library dependency in `build.gradle.kts`.
- **Infrastructure**:
    - Configured a new `skikoMain` source set in Gradle to share code between JVM and iOS.
    - Updated the "About Libraries" screen to manually include metadata for the Backdrop implementation.
    - Adjusted the blur amount slider range in `BlurSettingsScreen`.


Doing this since the external dependency currently crashes on desktop. Until Kyant updates, this is the solution