### PR TITLE
fix(auth): sign-in state now updates without an app restart

### DIFF
--- a/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/client/SupabaseClientProvider.kt
+++ b/favoritesdatabase/supabase-integration/src/commonMain/kotlin/com/programmersbox/supabaseintegration/client/SupabaseClientProvider.kt
@@ -11,37 +11,42 @@ import io.github.jan.supabase.storage.Storage
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class SupabaseClientProvider(
     private val credentialManager: CredentialManager,
     private val supabaseClientEngine: SupabaseClientEngine,
 ) {
     private val scope = CoroutineScope(Dispatchers.Default)
-    private var _client: SupabaseClient? = null
+    private val _clientState = MutableStateFlow<SupabaseClient?>(null)
+    val clientState: StateFlow<SupabaseClient?> = _clientState.asStateFlow()
 
-    val clientState: StateFlow<SupabaseClient?> = credentialManager.hasCredentials()
-        .map { hasCredentials -> if (hasCredentials) getOrCreate() else null }
-        .stateIn(scope, SharingStarted.Eagerly, null)
+    init {
+        scope.launch {
+            credentialManager.hasCredentials().collect { hasCredentials ->
+                _clientState.value = if (hasCredentials) getOrCreate() else null
+            }
+        }
+    }
 
     suspend fun getOrCreate(): SupabaseClient? {
+        _clientState.value?.let { return it }
         val credentials = credentialManager.getCredentials() ?: return null
-        if (_client == null) _client = buildClient(credentials)
-        return _client
+        return buildClient(credentials).also { _clientState.value = it }
     }
 
     suspend fun recreate(): SupabaseClient? {
-        _client?.close()
-        _client = null
+        _clientState.value?.close()
+        _clientState.value = null
         return getOrCreate()
     }
 
     suspend fun close() {
-        _client?.close()
-        _client = null
+        _clientState.value?.close()
+        _clientState.value = null
     }
 
     private fun buildClient(credentials: SupabaseCredentials): SupabaseClient =

--- a/favoritesdatabase/supabase-integration/src/jvmTest/kotlin/com/programmersbox/supabaseintegration/client/SupabaseClientProviderTest.kt
+++ b/favoritesdatabase/supabase-integration/src/jvmTest/kotlin/com/programmersbox/supabaseintegration/client/SupabaseClientProviderTest.kt
@@ -1,0 +1,59 @@
+package com.programmersbox.supabaseintegration.client
+
+import com.programmersbox.supabaseintegration.credentials.CredentialManager
+import com.programmersbox.supabaseintegration.credentials.SupabaseCredentials
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+private class FakeCredentialManager(
+    private var credentials: SupabaseCredentials? = null,
+) : CredentialManager {
+    private val _hasCredentials = MutableStateFlow(credentials != null)
+    override fun hasCredentials(): Flow<Boolean> = _hasCredentials
+    override suspend fun saveCredentials(credentials: SupabaseCredentials) {
+        this.credentials = credentials
+        _hasCredentials.value = true
+    }
+
+    override suspend fun getCredentials(): SupabaseCredentials? = credentials
+    override suspend fun clearCredentials() {
+        credentials = null
+        _hasCredentials.value = false
+    }
+}
+
+class SupabaseClientProviderTest {
+
+    private suspend fun awaitCondition(condition: suspend () -> Boolean) {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5_000) {
+                while (!condition()) delay(10)
+            }
+        }
+    }
+
+    @Test
+    fun `recreate publishes the new client through clientState even when credentials were already present`() = runTest {
+        val credentialManager = FakeCredentialManager(
+            credentials = SupabaseCredentials("https://example.supabase.co", "anon-key")
+        )
+        val provider = SupabaseClientProvider(credentialManager, SupabaseClientEngine())
+
+        awaitCondition { provider.clientState.value != null }
+        val firstClient = provider.clientState.value
+
+        val recreatedClient = provider.recreate()
+
+        assertNotSame(firstClient, recreatedClient)
+        awaitCondition { provider.clientState.value === recreatedClient }
+        assertSame(recreatedClient, provider.clientState.value)
+    }
+}


### PR DESCRIPTION
SupabaseClientProvider tracked the live client in a private field separate from the clientState StateFlow that AuthManager observes. recreate()/close() swapped the field directly, so clientState only picked up the new client when hasCredentials() flipped false->true. Any later recreate() (credentials already saved) left AuthManager listening to a stale, closed client — sign-in succeeded but the observed auth state never moved, requiring a restart to resync.

Make clientState itself the single source of truth so every getOrCreate/recreate/close call publishes immediately.