### PR TITLE
fix(desktop): include jdk.unsupported module in packaged runtime image

### DIFF
--- a/animeworld/desktop/build.gradle.kts
+++ b/animeworld/desktop/build.gradle.kts
@@ -82,6 +82,8 @@ compose.desktop {
             packageName = "AnimeWorld"
             packageVersion = "1.0.0"
 
+            modules("jdk.unsupported")
+
             windows {
                 iconFile.set(project.file("icons/icon.ico"))
             }

--- a/mangaworld/desktop/build.gradle.kts
+++ b/mangaworld/desktop/build.gradle.kts
@@ -91,6 +91,8 @@ compose.desktop {
             packageName = "MangaWorld"
             packageVersion = "1.0.0"
 
+            modules("jdk.unsupported")
+
             windows {
                 iconFile.set(project.file("icons/icon.ico"))
             }

--- a/novelworld/desktop/build.gradle.kts
+++ b/novelworld/desktop/build.gradle.kts
@@ -82,6 +82,8 @@ compose.desktop {
             packageName = "NovelWorld"
             packageVersion = "1.0.0"
 
+            modules("jdk.unsupported")
+
             windows {
                 iconFile.set(project.file("icons/icon.ico"))
             }


### PR DESCRIPTION
jlink-trimmed runtime for packageDistributionForCurrentOS drops jdk.unsupported since jdeps auto-detection misses reflective sun.misc.Unsafe usage from a transitive dep, causing NoClassDefFoundError at launch of the packaged binary.