### PR TITLE
feat(android): add notification count glance widget

### DIFF
--- a/datastore/src/androidMain/kotlin/com/programmersbox/datastore/PlatformDataStoreHandling.android.kt
+++ b/datastore/src/androidMain/kotlin/com/programmersbox/datastore/PlatformDataStoreHandling.android.kt
@@ -14,4 +14,9 @@ actual class PlatformDataStoreHandling {
         defaultValue = true
     )
 
+    val hasWidget = DataStoreHandler(
+        key = booleanPreferencesKey("has_widget"),
+        defaultValue = false
+    )
+
 }

--- a/datastore/src/commonMain/proto/settings.proto
+++ b/datastore/src/commonMain/proto/settings.proto
@@ -65,6 +65,8 @@ enum ThemeColor {
   Cyan = 6;
   Magenta = 7;
   Custom = 8;
+  Ugly = 9;
+  MyEyes = 10;
 }
 
 enum NotificationSortBy {

--- a/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/ItemDao.kt
+++ b/favoritesdatabase/src/commonMain/kotlin/com/programmersbox/favoritesdatabase/ItemDao.kt
@@ -1,6 +1,7 @@
 package com.programmersbox.favoritesdatabase
 
 import androidx.paging.PagingSource
+import androidx.room3.ColumnInfo
 import androidx.room3.Dao
 import androidx.room3.DaoReturnTypeConverters
 import androidx.room3.Delete
@@ -240,4 +241,28 @@ interface ItemDao {
 
     @Query("UPDATE ChapterWatched SET is_deleted = 0")
     suspend fun resetAllChaptersIsDeleted()
+
+    // Get the total number of active items
+    @Query("SELECT COUNT(*) FROM Notifications WHERE is_deleted = 0")
+    fun getTotalCountFlow(): Flow<Int>
+
+    // Group by source, sort by highest count, and limit to 4 for the widget grid
+    @Query(
+        """
+        SELECT source, COUNT(*) as count 
+        FROM Notifications 
+        WHERE is_deleted = 0 
+        GROUP BY source 
+        ORDER BY count DESC 
+        LIMIT 4
+    """
+    )
+    fun getTopSourcesFlow(): Flow<List<SourceCount>>
 }
+
+data class SourceCount(
+    @ColumnInfo(name = "source")
+    val source: String,
+    @ColumnInfo(name = "count")
+    val count: Int,
+)

--- a/gradle/android.versions.toml
+++ b/gradle/android.versions.toml
@@ -17,6 +17,7 @@ dragselect = "3.3.0"
 espresso-core = "3.7.0"
 firebaseBom = "34.17.0"
 generativeai = "0.9.0"
+glance = "1.3.0-alpha02"
 glideVersion = "5.0.9"
 junit = "1.3.0"
 koin-bom = "4.2.2"
@@ -48,6 +49,11 @@ zoomimageComposeGlide = "1.6.0"
 # Accompanist
 adaptive = { module = "com.google.accompanist:accompanist-adaptive", version.ref = "accompanist" }
 drawablePainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanist" }
+
+# Glance
+glance = { module = "androidx.glance:glance", version.ref = "glance" }
+glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
+glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance" }
 
 # Android Foundation
 androidBrowserHelper = "com.google.androidbrowserhelper:androidbrowserhelper:2.7.3"

--- a/kmpuiviews/build.gradle.kts
+++ b/kmpuiviews/build.gradle.kts
@@ -191,6 +191,9 @@ kotlin {
                 implementation(androidLibs.koin.workmanager)
                 implementation(androidx.paging.pagingCompose)
                 implementation(androidLibs.lifecycleProcess)
+                implementation(androidLibs.glance)
+                implementation(androidLibs.glance.appwidget)
+                implementation(androidLibs.glance.material3)
             }
         }
 

--- a/kmpuiviews/src/androidMain/AndroidManifest.xml
+++ b/kmpuiviews/src/androidMain/AndroidManifest.xml
@@ -37,6 +37,18 @@
             android:name=".receivers.PackageInstallReceiver"
             android:exported="false" />
 
+        <receiver
+            android:name=".widget.notification.NotificationWidgetReceiver"
+            android:exported="true"
+            android:label="Notification Count">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/notification_widget_info" />
+        </receiver>
+
     </application>
 
 </manifest>

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.android.kt
@@ -10,7 +10,11 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.programmersbox.kmpmodels.KmpItemModel
 import com.programmersbox.kmpuiviews.presentation.Screen
+import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import com.programmersbox.kmpuiviews.utils.DeepLinks
+import com.programmersbox.kmpuiviews.utils.composables.WidgetAddCard
+import com.programmersbox.kmpuiviews.utils.composables.widgetChecker
+import com.programmersbox.kmpuiviews.widget.notification.NotificationWidgetReceiver
 
 actual interface PlatformGenericInfo : KmpGenericInfo {
     val deepLinkUri: String
@@ -38,6 +42,16 @@ actual interface PlatformGenericInfo : KmpGenericInfo {
                 )
                 .toUri()
         } ?: "$deepLinkUri${Screen.DetailsScreen.route}".toUri()
+    }
+
+    override fun composeCustomPreferences(): ComposeSettingsDsl.() -> Unit = {
+        generalSettings {
+            val state = widgetChecker(NotificationWidgetReceiver::class.java)
+            WidgetAddCard(
+                widgetCheckerState = state.value,
+                description = "View saved notifications straight on your home screen!"
+            )
+        }
     }
 
     fun deepLinkSettingsUri() = deepLinks

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/KmpOtakuApp.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/KmpOtakuApp.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
 import com.programmersbox.datastore.DataStoreSettings
+import com.programmersbox.datastore.PlatformDataStoreHandling
 import com.programmersbox.favoritesdatabase.CustomListItem
 import com.programmersbox.favoritesdatabase.ItemDao
 import com.programmersbox.kmpextensionloader.SourceLoader
@@ -36,9 +37,10 @@ import com.programmersbox.supabaseintegration.repository.ActivityRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.get
-import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.workmanager.koin.workManagerFactory
@@ -104,13 +106,22 @@ abstract class KmpOtakuApp : Application(), Configuration.Provider {
             }
         })
 
+        val platformDataStoreHandling = get<PlatformDataStoreHandling>()
+        val itemDao = get<ItemDao>()
+
         GlobalScope.launch(Dispatchers.IO) {
-            NotificationWidget().updateAll(this@KmpOtakuApp)
-            getKoin()
-                .get<ItemDao>()
-                .getTotalCountFlow()
-                .flowOn(Dispatchers.IO)
-                .collect { NotificationWidget().updateAll(this@KmpOtakuApp) }
+            platformDataStoreHandling.hasWidget
+                .asFlow()
+                .onEach {
+                    if (it) {
+                        NotificationWidget().updateAll(this@KmpOtakuApp)
+                        itemDao
+                            .getTotalCountFlow()
+                            .flowOn(Dispatchers.IO)
+                            .collect { NotificationWidget().updateAll(this@KmpOtakuApp) }
+                    }
+                }
+                .launchIn(this)
         }
     }
 

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/KmpOtakuApp.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/KmpOtakuApp.kt
@@ -13,12 +13,14 @@ import androidx.compose.runtime.Composer
 import androidx.compose.runtime.ExperimentalComposeRuntimeApi
 import androidx.compose.runtime.tooling.ComposeStackTraceMode
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.glance.appwidget.updateAll
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
 import com.programmersbox.datastore.DataStoreSettings
 import com.programmersbox.favoritesdatabase.CustomListItem
+import com.programmersbox.favoritesdatabase.ItemDao
 import com.programmersbox.kmpextensionloader.SourceLoader
 import com.programmersbox.kmpuiviews.di.kmpModule
 import com.programmersbox.kmpuiviews.repository.BackgroundWorkHandler
@@ -29,11 +31,14 @@ import com.programmersbox.kmpuiviews.utils.NotificationChannels
 import com.programmersbox.kmpuiviews.utils.NotificationGroups
 import com.programmersbox.kmpuiviews.utils.OtakuLogger
 import com.programmersbox.kmpuiviews.utils.printLogs
+import com.programmersbox.kmpuiviews.widget.notification.NotificationWidget
 import com.programmersbox.supabaseintegration.repository.ActivityRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.get
+import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.workmanager.koin.workManagerFactory
@@ -92,7 +97,6 @@ abstract class KmpOtakuApp : Application(), Configuration.Provider {
         shortcutSetup()
 
         val activityRepository = get<ActivityRepository>()
-        GlobalScope.launch(Dispatchers.IO) { activityRepository.migrateFromDataStoreIfNeeded() }
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onStop(owner: LifecycleOwner) {
@@ -100,12 +104,14 @@ abstract class KmpOtakuApp : Application(), Configuration.Provider {
             }
         })
 
-        /*runCatching {
-            get<ServerRepository>()
-                .init()
-                .launchIn(GlobalScope)
-        }*/
-
+        GlobalScope.launch(Dispatchers.IO) {
+            NotificationWidget().updateAll(this@KmpOtakuApp)
+            getKoin()
+                .get<ItemDao>()
+                .getTotalCountFlow()
+                .flowOn(Dispatchers.IO)
+                .collect { NotificationWidget().updateAll(this@KmpOtakuApp) }
+        }
     }
 
     abstract val isDebug: Boolean

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/utils/composables/WidgetChecker.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/utils/composables/WidgetChecker.kt
@@ -1,0 +1,137 @@
+package com.programmersbox.kmpuiviews.utils.composables
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.favoritesdatabase.ItemDao
+import com.programmersbox.kmpuiviews.widget.notification.TextOnlyWidgetContentPreview
+import com.programmersbox.kmpuiviews.widget.notification.WidgetDataState
+import com.programmersbox.kmpuiviews.widget.notification.getWidgetStateFlow
+import org.koin.compose.koinInject
+
+@Composable
+fun <T> widgetChecker(
+    clazz: Class<T>,
+): State<WidgetCheckerState> {
+    val context = LocalContext.current
+
+    val appWidgetManager = remember(context) {
+        AppWidgetManager.getInstance(context)
+    }
+
+    val appUsageWidget = remember(context) {
+        ComponentName(context, clazz)
+    }
+
+    val hasActiveWidgetIds = remember { mutableStateOf(true) }
+
+    LifecycleResumeEffect(Unit) {
+        runCatching {
+            hasActiveWidgetIds.value = appWidgetManager
+                .getAppWidgetIds(appUsageWidget)
+                .isNotEmpty()
+        }
+        onPauseOrDispose {}
+    }
+
+    return remember(hasActiveWidgetIds, context) {
+        derivedStateOf {
+            WidgetCheckerState(
+                appWidgetManager = appWidgetManager,
+                componentName = appUsageWidget,
+                hasActiveWidgetIds = hasActiveWidgetIds.value
+            )
+        }
+    }
+}
+
+data class WidgetCheckerState(
+    val appWidgetManager: AppWidgetManager,
+    val componentName: ComponentName,
+    val hasActiveWidgetIds: Boolean,
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun WidgetAddCard(
+    widgetCheckerState: WidgetCheckerState,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
+    val itemDao = koinInject<ItemDao>()
+    val widgetState by getWidgetStateFlow(itemDao).collectAsStateWithLifecycle(WidgetDataState())
+    Card(
+        shape = MaterialTheme.shapes.extraLarge,
+        modifier = modifier.animateContentSize()
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                "Add as widget",
+                modifier = Modifier.align(Alignment.Start)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            TextOnlyWidgetContentPreview(
+                state = widgetState,
+                modifier = Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .height(140.dp)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Description
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                modifier = Modifier.align(Alignment.Start)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Button(
+                onClick = {
+                    widgetCheckerState
+                        .appWidgetManager
+                        .requestPinAppWidget(
+                            widgetCheckerState.componentName,
+                            null,
+                            null
+                        )
+                },
+                shapes = ButtonDefaults.shapes()
+            ) { Text(text = "Add Widget") }
+        }
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/WidgetTheme.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/WidgetTheme.kt
@@ -1,0 +1,45 @@
+package com.programmersbox.kmpuiviews.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.glance.GlanceComposable
+import androidx.glance.GlanceTheme
+import androidx.glance.material3.ColorProviders
+import com.materialkolor.PaletteStyle
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.Settings
+import org.koin.compose.koinInject
+
+@Composable
+fun WidgetTheme(
+    settingsHandling: NewSettingsHandling = koinInject(),
+    content: @GlanceComposable @Composable () -> Unit,
+) {
+    val settings by settingsHandling.preferences.data.collectAsState(Settings())
+    val swatchStyle by rememberPreferenceForWidget(
+        key = stringPreferencesKey("swatchStyle"),
+        mapToType = { runCatching { PaletteStyle.valueOf(it) }.getOrDefault(PaletteStyle.TonalSpot) },
+        mapToKey = { it.name },
+        defaultValue = PaletteStyle.TonalSpot
+    )
+
+    val (light, dark) = createWidgetScheme(
+        darkTheme = false,
+        settings = settings,
+        swatchStyle = swatchStyle
+    ) to createWidgetScheme(
+        darkTheme = true,
+        settings = settings,
+        swatchStyle = swatchStyle
+    )
+
+    GlanceTheme(
+        ColorProviders(
+            light = light,
+            dark = dark
+        ),
+        content = content
+    )
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/WidgetUtils.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/WidgetUtils.kt
@@ -1,0 +1,123 @@
+package com.programmersbox.kmpuiviews.widget
+
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.expressiveLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.Color
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.glance.LocalContext
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.ktx.animateColorScheme
+import com.materialkolor.rememberDynamicColorScheme
+import com.programmersbox.datastore.Settings
+import com.programmersbox.datastore.ThemeColor
+import com.programmersbox.datastore.otakuDataStore
+import com.programmersbox.kmpuiviews.utils.seedColor
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+
+//TODO: Widget ideas
+// Maybe favorite count with a small chart?
+// Maybe read time count?
+
+@Composable
+fun <T, R> rememberPreferenceForWidget(
+    key: Preferences.Key<T>,
+    mapToType: (T) -> R?,
+    mapToKey: (R) -> T,
+    defaultValue: R,
+): MutableState<R> {
+    val coroutineScope = rememberCoroutineScope()
+    val state by remember {
+        otakuDataStore
+            .data
+            .mapNotNull { it[key]?.let(mapToType) ?: defaultValue }
+            .distinctUntilChanged()
+    }.collectAsState(defaultValue)
+
+    return remember(state) {
+        object : MutableState<R> {
+            override var value: R
+                get() = state
+                set(value) {
+                    coroutineScope.launch {
+                        otakuDataStore.edit { it[key] = value.let(mapToKey) }
+                    }
+                }
+
+            override fun component1() = value
+            override fun component2(): (R) -> Unit = { value = it }
+        }
+    }
+}
+
+@Composable
+private fun createColorScheme(
+    darkTheme: Boolean,
+    isExpressive: Boolean,
+): ColorScheme {
+    val context = LocalContext.current
+    return remember(context, darkTheme, isExpressive) {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && darkTheme -> dynamicDarkColorScheme(context)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !darkTheme -> dynamicLightColorScheme(context)
+            darkTheme -> darkColorScheme(
+                primary = Color(0xff90CAF9),
+                secondary = Color(0xff90CAF9)
+            )
+
+            isExpressive -> expressiveLightColorScheme()
+
+            else -> lightColorScheme()
+        }
+    }
+}
+
+@Composable
+fun createWidgetScheme(
+    darkTheme: Boolean,
+    settings: Settings,
+    swatchStyle: PaletteStyle,
+): ColorScheme {
+    val isAmoledMode = settings.amoledMode
+    val isExpressive = settings.showExpressiveness
+    val themeColor = settings.themeColor
+
+    val colorScheme = if (themeColor == ThemeColor.Dynamic) {
+        createColorScheme(darkTheme, isExpressive).let {
+            if (isAmoledMode && darkTheme) {
+                it.copy(
+                    surface = Color.Black,
+                    onSurface = Color.White,
+                    background = Color.Black,
+                    onBackground = Color.White,
+                )
+            } else {
+                it
+            }
+        }
+    } else {
+        rememberDynamicColorScheme(
+            seedColor = themeColor.seedColor,
+            isAmoled = isAmoledMode,
+            isDark = darkTheme,
+            style = swatchStyle,
+            specVersion = ColorSpec.SpecVersion.SPEC_2025
+        )
+    }
+
+    return animateColorScheme(remember(isAmoledMode, isExpressive, themeColor, colorScheme) { colorScheme })
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidget.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidget.kt
@@ -1,0 +1,161 @@
+package com.programmersbox.kmpuiviews.widget.notification
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.appWidgetBackground
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import com.programmersbox.favoritesdatabase.ItemDao
+import com.programmersbox.favoritesdatabase.SourceCount
+import com.programmersbox.kmpuiviews.widget.WidgetTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class NotificationWidget : GlanceAppWidget(), KoinComponent {
+    private val itemDao by inject<ItemDao>()
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            val state by getWidgetStateFlow().collectAsState(WidgetDataState())
+
+            WidgetTheme {
+                TextOnlyWidgetContent(
+                    state = state
+                )
+            }
+        }
+    }
+
+    fun getWidgetStateFlow(): Flow<WidgetDataState> {
+        return combine(
+            itemDao.getTotalCountFlow(),
+            itemDao.getTopSourcesFlow()
+        ) { total, sources ->
+            WidgetDataState(totalCount = total, topSources = sources)
+        }
+    }
+}
+
+data class WidgetDataState(
+    val totalCount: Int = 0,
+    val topSources: List<SourceCount> = emptyList(),
+)
+
+@Composable
+private fun TextOnlyWidgetContent(state: WidgetDataState) {
+    Column(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(GlanceTheme.colors.surface)
+            .appWidgetBackground()
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "SAVED ITEMS",
+                style = TextStyle(
+                    color = GlanceTheme.colors.onSurface,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                modifier = GlanceModifier.defaultWeight()
+            )
+            Text(
+                text = state.totalCount.toString(),
+                style = TextStyle(
+                    color = GlanceTheme.colors.onSurface,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.End
+                ),
+                modifier = GlanceModifier.defaultWeight()
+            )
+        }
+
+        Spacer(modifier = GlanceModifier.height(8.dp))
+
+        // Render the Dynamic 2x2 Grid
+        val sources = state.topSources
+        LazyColumn(modifier = GlanceModifier.fillMaxWidth()) {
+            items(sources.chunked(2)) {
+                Row(
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .padding(bottom = 6.dp)
+                ) {
+                    SourceItemSafe(source = sources.getOrNull(0), modifier = GlanceModifier.defaultWeight())
+                    Spacer(modifier = GlanceModifier.width(16.dp))
+                    SourceItemSafe(source = sources.getOrNull(1), modifier = GlanceModifier.defaultWeight())
+                }
+            }
+        }
+    }
+}
+
+// A safe wrapper that renders an empty space if the source doesn't exist
+// (e.g., if the user only has 1 or 3 sources total)
+@Composable
+private fun SourceItemSafe(source: SourceCount?, modifier: GlanceModifier) {
+    if (source == null) {
+        Spacer(modifier = modifier)
+    } else {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .background(GlanceTheme.colors.primaryContainer)
+                .padding(12.dp)
+                .cornerRadius(16.dp)
+        ) {
+            Text(
+                text = source.source,
+                style = TextStyle(
+                    color = GlanceTheme.colors.onPrimaryContainer,
+                ),
+                maxLines = 1, // Prevents long source names from breaking the layout
+                // 1. Move defaultWeight() here so the text truncates instead of expanding
+                modifier = GlanceModifier.defaultWeight()
+            )
+
+            // 2. Change the spacer to a fixed width so there is always a small gap
+            // between a long name and the count.
+            Spacer(modifier = GlanceModifier.width(8.dp))
+
+            Text(
+                text = source.count.toString(),
+                style = TextStyle(
+                    color = GlanceTheme.colors.onPrimaryContainer,
+                    fontWeight = FontWeight.Medium
+                ),
+            )
+        }
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidget.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidget.kt
@@ -42,7 +42,7 @@ class NotificationWidget : GlanceAppWidget(), KoinComponent {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         provideContent {
-            val state by getWidgetStateFlow().collectAsState(WidgetDataState())
+            val state by getWidgetStateFlow(itemDao).collectAsState(WidgetDataState())
 
             WidgetTheme {
                 TextOnlyWidgetContent(
@@ -51,14 +51,16 @@ class NotificationWidget : GlanceAppWidget(), KoinComponent {
             }
         }
     }
+}
 
-    fun getWidgetStateFlow(): Flow<WidgetDataState> {
-        return combine(
-            itemDao.getTotalCountFlow(),
-            itemDao.getTopSourcesFlow()
-        ) { total, sources ->
-            WidgetDataState(totalCount = total, topSources = sources)
-        }
+fun getWidgetStateFlow(
+    itemDao: ItemDao,
+): Flow<WidgetDataState> {
+    return combine(
+        itemDao.getTotalCountFlow(),
+        itemDao.getTopSourcesFlow()
+    ) { total, sources ->
+        WidgetDataState(totalCount = total, topSources = sources)
     }
 }
 

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetPreview.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetPreview.kt
@@ -1,0 +1,122 @@
+package com.programmersbox.kmpuiviews.widget.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.programmersbox.favoritesdatabase.SourceCount
+
+@Composable
+fun TextOnlyWidgetContentPreview(
+    state: WidgetDataState,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .clip(MaterialTheme.shapes.extraLarge)
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "SAVED ITEMS",
+                style = TextStyle(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = state.totalCount.toString(),
+                style = TextStyle(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.End
+                ),
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Render the Dynamic 2x2 Grid
+        val sources = state.topSources
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            items(sources.chunked(2)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 6.dp)
+                ) {
+                    SourceItemSafe(source = sources.getOrNull(0), modifier = Modifier.weight(1f))
+                    Spacer(modifier = Modifier.width(16.dp))
+                    SourceItemSafe(source = sources.getOrNull(1), modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+// A safe wrapper that renders an empty space if the source doesn't exist
+// (e.g., if the user only has 1 or 3 sources total)
+@Composable
+private fun SourceItemSafe(source: SourceCount?, modifier: Modifier) {
+    if (source == null) {
+        Spacer(modifier = modifier)
+    } else {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .padding(12.dp)
+        ) {
+            Text(
+                text = source.source,
+                style = TextStyle(
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+                maxLines = 1, // Prevents long source names from breaking the layout
+                // 1. Move defaultWeight() here so the text truncates instead of expanding
+                modifier = Modifier.weight(1f)
+            )
+
+            // 2. Change the spacer to a fixed width so there is always a small gap
+            // between a long name and the count.
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = source.count.toString(),
+                style = TextStyle(
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    fontWeight = FontWeight.Medium
+                ),
+            )
+        }
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetReceiver.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetReceiver.kt
@@ -1,0 +1,10 @@
+package com.programmersbox.kmpuiviews.widget.notification
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class NotificationWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = NotificationWidget()
+}
+
+

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetReceiver.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/widget/notification/NotificationWidgetReceiver.kt
@@ -1,10 +1,31 @@
 package com.programmersbox.kmpuiviews.widget.notification
 
+import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import com.programmersbox.datastore.PlatformDataStoreHandling
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class NotificationWidgetReceiver : GlanceAppWidgetReceiver() {
+class NotificationWidgetReceiver : GlanceAppWidgetReceiver(), KoinComponent {
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val platformDataStoreHandling by inject<PlatformDataStoreHandling>()
+
     override val glanceAppWidget: GlanceAppWidget = NotificationWidget()
+
+    override fun onEnabled(context: Context?) {
+        super.onEnabled(context)
+        scope.launch { platformDataStoreHandling.hasWidget.set(true) }
+    }
+
+    override fun onDisabled(context: Context?) {
+        scope.launch { platformDataStoreHandling.hasWidget.set(false) }
+        super.onDisabled(context)
+    }
 }
 
 

--- a/kmpuiviews/src/androidMain/res/xml/notification_widget_info.xml
+++ b/kmpuiviews/src/androidMain/res/xml/notification_widget_info.xml
@@ -4,7 +4,7 @@
     android:minHeight="40dp"
     android:minResizeWidth="110dp"
     android:minResizeHeight="40dp"
-    android:targetCellWidth="2"
+    android:targetCellWidth="4"
     android:targetCellHeight="2"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"

--- a/kmpuiviews/src/androidMain/res/xml/notification_widget_info.xml
+++ b/kmpuiviews/src/androidMain/res/xml/notification_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetFeatures="reconfigurable|configuration_optional"
+    android:initialLayout="@layout/glance_default_loading_layout" />

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/ThemeSettingsScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/ThemeSettingsScreen.kt
@@ -40,6 +40,8 @@ import com.programmersbox.kmpuiviews.presentation.components.settings.Preference
 import com.programmersbox.kmpuiviews.presentation.components.settings.ShowMoreSetting
 import com.programmersbox.kmpuiviews.presentation.components.settings.SwitchSetting
 import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
+import com.programmersbox.kmpuiviews.theme.UglyDarkColorScheme
+import com.programmersbox.kmpuiviews.theme.UglyLightColorScheme
 import com.programmersbox.kmpuiviews.utils.seedColor
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -147,10 +149,21 @@ fun ThemeSetting(
                         themeColor = it,
                         onClick = { themeColor = it },
                         selected = it == themeColor,
-                        colorScheme = if (it == ThemeColor.Dynamic)
-                            MaterialTheme.colorScheme
-                        else
-                            rememberDynamicColorScheme(
+                        colorScheme = when (it) {
+                            ThemeColor.Dynamic -> MaterialTheme.colorScheme
+                            ThemeColor.Ugly -> when (themeSetting) {
+                                SystemThemeMode.FollowSystem -> if (isSystemInDarkTheme()) UglyDarkColorScheme else UglyLightColorScheme
+                                SystemThemeMode.Day -> UglyLightColorScheme
+                                SystemThemeMode.Night -> UglyDarkColorScheme
+                            }
+
+                            ThemeColor.MyEyes -> when (themeSetting) {
+                                SystemThemeMode.FollowSystem -> if (isSystemInDarkTheme()) UglyDarkColorScheme else UglyLightColorScheme
+                                SystemThemeMode.Day -> UglyLightColorScheme
+                                SystemThemeMode.Night -> UglyDarkColorScheme
+                            }
+
+                            else -> rememberDynamicColorScheme(
                                 it.seedColor,
                                 isDark = when (themeSetting) {
                                     SystemThemeMode.FollowSystem -> isSystemInDarkTheme()
@@ -159,6 +172,7 @@ fun ThemeSetting(
                                 },
                                 isAmoled = isAmoledMode
                             )
+                        }
                     )
                 }
         }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/MyEyesScheme.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/MyEyesScheme.kt
@@ -1,0 +1,46 @@
+package com.programmersbox.kmpuiviews.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+// The absolute worst colors imaginable
+private val NeonGreen = Color(0xFF00FF00)
+private val HotPink = Color(0xFFFF00FF)
+private val MuddyBrown = Color(0xFF4E342E)
+private val Cyan = Color(0xFF00FFFF)
+private val EyeBleedYellow = Color(0xFFFFFF00)
+private val BrightRed = Color(0xFFFF0000)
+private val DarkRed = Color(0xFF8B0000)
+private val SolidBlue = Color(0xFF0000FF)
+private val NavyBlue = Color(0xFF000080)
+
+val UglyLightColorScheme = lightColorScheme(
+    primary = NeonGreen,
+    onPrimary = HotPink,         // Vibrating colors when placed together
+    secondary = MuddyBrown,
+    onSecondary = Cyan,          // Muddy and neon clash
+    tertiary = EyeBleedYellow,
+    onTertiary = SolidBlue,
+    background = BrightRed,
+    onBackground = DarkRed,      // Impossible to read text
+    surface = SolidBlue,
+    onSurface = NavyBlue,        // Impossible to read text, part 2
+    error = NeonGreen,           // Errors are green now. Chaos.
+    onError = EyeBleedYellow
+)
+
+val UglyDarkColorScheme = darkColorScheme(
+    primary = HotPink,
+    onPrimary = NeonGreen,
+    secondary = Cyan,
+    onSecondary = MuddyBrown,
+    tertiary = SolidBlue,
+    onTertiary = EyeBleedYellow,
+    background = EyeBleedYellow, // A literal flashbang in dark mode
+    onBackground = SolidBlue,
+    surface = MuddyBrown,
+    onSurface = BrightRed,       // Terrible contrast on cards
+    error = Cyan,
+    onError = HotPink
+)

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/OtakuColorScheme.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/OtakuColorScheme.kt
@@ -30,29 +30,36 @@ fun generateColorScheme(
         SystemThemeMode.Night -> true
     }
 
-    val colorScheme = if (themeColor == ThemeColor.Dynamic) {
-        createColorScheme(darkTheme, isExpressive).let {
-            if (isAmoledMode && darkTheme) {
-                it.copy(
-                    surface = Color.Black,
-                    onSurface = Color.White,
-                    background = Color.Black,
-                    onBackground = Color.White,
-                )
-            } else {
-                it
+    val colorScheme = when (themeColor) {
+        ThemeColor.Dynamic -> {
+            createColorScheme(darkTheme, isExpressive).let {
+                if (isAmoledMode && darkTheme) {
+                    it.copy(
+                        surface = Color.Black,
+                        onSurface = Color.White,
+                        background = Color.Black,
+                        onBackground = Color.White,
+                    )
+                } else {
+                    it
+                }
             }
         }
-    } else {
-        val swatchStyle by rememberSwatchStyle()
 
-        rememberDynamicColorScheme(
-            seedColor = themeColor.seedColor,
-            isAmoled = isAmoledMode,
-            isDark = darkTheme,
-            style = swatchStyle,
-            specVersion = ColorSpec.SpecVersion.SPEC_2025
-        )
+        ThemeColor.Ugly -> if (darkTheme) FullyUglyDarkColorScheme else FullyUglyLightColorScheme
+        ThemeColor.MyEyes -> if (darkTheme) UglyDarkColorScheme else UglyLightColorScheme
+
+        else -> {
+            val swatchStyle by rememberSwatchStyle()
+
+            rememberDynamicColorScheme(
+                seedColor = themeColor.seedColor,
+                isAmoled = isAmoledMode,
+                isDark = darkTheme,
+                style = swatchStyle,
+                specVersion = ColorSpec.SpecVersion.SPEC_2025
+            )
+        }
     }
 
     return animateColorScheme(remember(isAmoledMode, isExpressive, themeColor, themeSetting, colorScheme) { colorScheme })

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/UglyScheme.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/theme/UglyScheme.kt
@@ -1,0 +1,107 @@
+package com.programmersbox.kmpuiviews.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+
+// The Extended Arsenal of Eye Pain
+private val RadioactiveGreen = Color(0xFF00FF00)
+private val PeptoPink = Color(0xFFFF69B4)
+private val ScreamingOrange = Color(0xFFFF4500)
+private val Windows95Teal = Color(0xFF008080)
+private val BruisePurple = Color(0xFF3A004C)
+private val HighlighterYellow = Color(0xFFE8FF00)
+private val AshenGray = Color(0xFFB0B0B0)
+private val Rust = Color(0xFF8B4513)
+private val ToxicSludge = Color(0xFF4C5803)
+private val DepressingBeige = Color(0xFFE3DCC8)
+
+val FullyUglyLightColorScheme = lightColorScheme(
+    // Primary colors (Buttons, active states)
+    primary = RadioactiveGreen,
+    onPrimary = PeptoPink,
+    primaryContainer = ScreamingOrange,
+    onPrimaryContainer = Windows95Teal,
+
+    // Secondary colors (FABs, selection controls)
+    secondary = BruisePurple,
+    onSecondary = ToxicSludge,
+    secondaryContainer = Rust,
+    onSecondaryContainer = BruisePurple, // Zero contrast container text
+
+    // Tertiary colors (Contrasting accents, badges)
+    tertiary = HighlighterYellow,
+    onTertiary = AshenGray,
+    tertiaryContainer = Windows95Teal,
+    onTertiaryContainer = RadioactiveGreen,
+
+    // Error colors (Complete mental model breakage)
+    error = DepressingBeige,          // Errors look like boring disabled states
+    onError = AshenGray,
+    errorContainer = ToxicSludge,     // Error backgrounds look like swamp water
+    onErrorContainer = PeptoPink,
+
+    // Background and Surface (The foundation of your app)
+    background = ScreamingOrange,
+    onBackground = Rust,              // Barely visible on orange
+    surface = PeptoPink,              // All cards are now pink
+    onSurface = HighlighterYellow,    // Unreadable yellow text on pink cards
+    surfaceVariant = ToxicSludge,     // Segmented buttons/bottom sheets are sludge
+    onSurfaceVariant = BruisePurple,
+
+    // Borders and Dividers
+    outline = HighlighterYellow,      // Text field borders will burn your eyes
+    outlineVariant = ScreamingOrange, // Dividers that blend into the background
+
+    // Inverse colors (Snackbars)
+    inverseSurface = RadioactiveGreen,
+    inverseOnSurface = PeptoPink,
+    inversePrimary = BruisePurple,
+
+    // Scrim (The background dim when a drawer/dialog opens)
+    scrim = HighlighterYellow,        // Instead of dimming, dialogs flashbang the user
+
+    // Surface Tint (Elevation overlay)
+    surfaceTint = Rust
+)
+
+val FullyUglyDarkColorScheme = darkColorScheme(
+    primary = Windows95Teal,
+    onPrimary = ScreamingOrange,
+    primaryContainer = ToxicSludge,
+    onPrimaryContainer = HighlighterYellow,
+
+    secondary = PeptoPink,
+    onSecondary = RadioactiveGreen,
+    secondaryContainer = AshenGray,
+    onSecondaryContainer = DepressingBeige,
+
+    tertiary = Rust,
+    onTertiary = BruisePurple,
+    tertiaryContainer = ScreamingOrange,
+    onTertiaryContainer = ToxicSludge,
+
+    error = RadioactiveGreen,         // Errors are 'success' green in dark mode
+    onError = BruisePurple,
+    errorContainer = HighlighterYellow,
+    onErrorContainer = AshenGray,
+
+    // The "Dark" mode background is blindingly bright
+    background = HighlighterYellow,
+    onBackground = AshenGray,
+    surface = ScreamingOrange,
+    onSurface = RadioactiveGreen,
+    surfaceVariant = PeptoPink,
+    onSurfaceVariant = Rust,
+
+    outline = ToxicSludge,
+    outlineVariant = Windows95Teal,
+
+    inverseSurface = DepressingBeige,
+    inverseOnSurface = ToxicSludge,
+    inversePrimary = ScreamingOrange,
+
+    scrim = PeptoPink, // Dialogs bathe the screen in pink
+    surfaceTint = HighlighterYellow
+)

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/ComposableUtils.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/ComposableUtils.kt
@@ -45,7 +45,7 @@ val ThemeColor.seedColor
         ThemeColor.Yellow -> Color.Yellow
         ThemeColor.Cyan -> Color.Cyan
         ThemeColor.Magenta -> Color.Magenta
-        ThemeColor.Custom -> Color.Transparent
+        else -> Color.Transparent
     }
 
 enum class ComponentState { Pressed, Released }

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/ComposeSettingsDsl.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/utils/ComposeSettingsDsl.kt
@@ -5,93 +5,175 @@ import com.programmersbox.kmpuiviews.presentation.components.settings.CategoryGr
 import com.programmersbox.kmpuiviews.presentation.onboarding.OnboardingScope
 
 class ComposeSettingsDsl {
-    //TODO: Turn back to internal once settings move to kmpuiviews
     var generalSettings: @Composable () -> Unit = {}
+        private set
     var viewSettings: CategoryGroupScope.() -> Unit = {}
+        private set
     var playerSettings: @Composable () -> Unit = {}
-
+        private set
     var onboardingSettings: OnboardingScope.() -> Unit = {}
+        private set
 
     fun generalSettings(block: @Composable () -> Unit) {
-        generalSettings = block
+        val previous = generalSettings
+        generalSettings = {
+            previous()
+            block()
+        }
     }
 
     fun viewSettings(block: CategoryGroupScope.() -> Unit) {
-        viewSettings = block
+        val previous = viewSettings
+        viewSettings = {
+            previous()
+            block()
+        }
     }
 
     fun playerSettings(block: @Composable () -> Unit) {
-        playerSettings = block
+        val previous = playerSettings
+        playerSettings = {
+            previous()
+            block()
+        }
     }
 
     fun onboardingSettings(block: OnboardingScope.() -> Unit) {
-        onboardingSettings = block
+        val previous = onboardingSettings
+        onboardingSettings = {
+            previous()
+            block()
+        }
     }
 
     // ── New: per-section injection ───────────────────────────
     var quickActionsSettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun quickActionsSettings(block: CategoryGroupScope.() -> Unit) {
-        quickActionsSettings = block
+        val previous = quickActionsSettings
+        quickActionsSettings = {
+            previous()
+            block()
+        }
     }
 
     var librarySettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun librarySettings(block: CategoryGroupScope.() -> Unit) {
-        librarySettings = block
+        val previous = librarySettings
+        librarySettings = {
+            previous()
+            block()
+        }
     }
 
     var discoverSettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun discoverSettings(block: CategoryGroupScope.() -> Unit) {
-        discoverSettings = block
+        val previous = discoverSettings
+        discoverSettings = {
+            previous()
+            block()
+        }
     }
 
     var sourcesSettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun sourcesSettings(block: CategoryGroupScope.() -> Unit) {
-        sourcesSettings = block
+        val previous = sourcesSettings
+        sourcesSettings = {
+            previous()
+            block()
+        }
     }
 
     var integrationsSettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun integrationsSettings(block: CategoryGroupScope.() -> Unit) {
-        integrationsSettings = block
+        val previous = integrationsSettings
+        integrationsSettings = {
+            previous()
+            block()
+        }
     }
 
     var appearanceSettings: @Composable () -> Unit = {}
+        private set
 
     fun appearanceSettings(block: @Composable () -> Unit) {
-        appearanceSettings = block
+        val previous = appearanceSettings
+        appearanceSettings = {
+            previous()
+            block()
+        }
     }
 
     var behaviorSettings: @Composable () -> Unit = {}
+        private set
 
     fun behaviorSettings(block: @Composable () -> Unit) {
-        behaviorSettings = block
+        val previous = behaviorSettings
+        behaviorSettings = {
+            previous()
+            block()
+        }
     }
 
     var layoutSettings: @Composable () -> Unit = {}
+        private set
 
     fun layoutSettings(block: @Composable () -> Unit) {
-        layoutSettings = block
+        val previous = layoutSettings
+        layoutSettings = {
+            previous()
+            block()
+        }
     }
 
     var contentReadingSettings: @Composable () -> Unit = {}
+        private set
 
     fun contentReadingSettings(block: @Composable () -> Unit) {
-        contentReadingSettings = block
+        val previous = contentReadingSettings
+        contentReadingSettings = {
+            previous()
+            block()
+        }
     }
 
     var dataSettings: @Composable () -> Unit = {}
+        private set
 
     fun dataSettings(block: @Composable () -> Unit) {
-        dataSettings = block
+        val previous = dataSettings
+        dataSettings = {
+            previous()
+            block()
+        }
     }
 
     var aboutSettings: CategoryGroupScope.() -> Unit = {}
+        private set
 
     fun aboutSettings(block: CategoryGroupScope.() -> Unit) {
-        aboutSettings = block
+        val previous = aboutSettings
+        aboutSettings = {
+            previous()
+            block()
+        }
+    }
+}
+
+operator fun (ComposeSettingsDsl.() -> Unit).plus(
+    other: ComposeSettingsDsl.() -> Unit,
+): ComposeSettingsDsl.() -> Unit {
+    return {
+        this@plus.invoke(this) // Execute the left side's lambda on the DSL instance
+        other.invoke(this)     // Execute the right side's lambda on the DSL instance
     }
 }

--- a/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/GenericMangaDesktop.kt
+++ b/mangaworld/desktop/src/jvmMain/kotlin/com/programmersbox/desktop/GenericMangaDesktop.kt
@@ -107,28 +107,14 @@ class GenericMangaDesktop(
 
     @OptIn(ExperimentalMaterial3ExpressiveApi::class)
     override fun composeCustomPreferences(): ComposeSettingsDsl.() -> Unit {
-        val compose = ComposeSettingsDsl()
-            .apply(super<GenericSharedManga>.composeCustomPreferences())
-
         return {
             viewSettings {
-                compose.viewSettings(this)
-
                 segmentedListItem(
                     content = { Text("Platform Settings") },
                     leadingContent = { Icon(Icons.Default.DesktopMac, null) },
                     onClick = { navigationActions.navigate(PlatformSettings) }
                 )
-
-                /*segmentedListItem(
-                    content = { Text("Custom Scraper") },
-                    leadingContent = { Icon(Icons.Default.Bolt, null) },
-                    onClick = { navigationActions.navigate(CustomScraper) }
-                )*/
             }
-            generalSettings = compose.generalSettings
-            onboardingSettings = compose.onboardingSettings
-            playerSettings = compose.playerSettings
         }
     }
 }

--- a/mangaworld/src/main/java/com/programmersbox/mangaworld/GenericManga.kt
+++ b/mangaworld/src/main/java/com/programmersbox/mangaworld/GenericManga.kt
@@ -12,8 +12,10 @@ import com.programmersbox.kmpmodels.KmpItemModel
 import com.programmersbox.kmpuiviews.SystemAlerter
 import com.programmersbox.kmpuiviews.presentation.navactions.NavigationActions
 import com.programmersbox.kmpuiviews.utils.AppConfig
+import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import com.programmersbox.kmpuiviews.utils.NotificationLogo
 import com.programmersbox.kmpuiviews.utils.Zipper
+import com.programmersbox.kmpuiviews.utils.plus
 import com.programmersbox.manga.shared.ChapterHolder
 import com.programmersbox.manga.shared.GenericSharedManga
 import com.programmersbox.manga.shared.downloads.DownloadChapterWorker
@@ -103,6 +105,10 @@ class GenericManga(
                 }
             )
         }
+    }
+
+    override fun composeCustomPreferences(): ComposeSettingsDsl.() -> Unit {
+        return super<GenericSharedManga>.composeCustomPreferences() + super<GenericInfo>.composeCustomPreferences()
     }
 
     override fun deepLinkDetails(context: Context, itemModel: KmpItemModel?): PendingIntent? {

--- a/sharedtools/src/commonMain/kotlin/com/programmersbox/sharedtools/FlowUtils.kt
+++ b/sharedtools/src/commonMain/kotlin/com/programmersbox/sharedtools/FlowUtils.kt
@@ -1,0 +1,19 @@
+package com.programmersbox.sharedtools
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+
+/**
+ * Cancels the flow gracefully after the given total duration,
+ * regardless of emission frequency.
+ */
+fun <T> Flow<T>.cancelAfter(duration: Duration): Flow<T> = flow {
+    withTimeoutOrNull(duration) {
+        // "this@cancelAfter" refers to the upstream flow
+        this@cancelAfter.collect { value ->
+            emit(value)
+        }
+    }
+}


### PR DESCRIPTION
Implement a new Android home screen widget using Jetpack Glance to display notification statistics.

- **favoritesdatabase**: Add `getTotalCountFlow` and `getTopSourcesFlow` queries to `ItemDao` to fetch active notification counts and top 4 sources.
- **kmpuiviews**:
    - Implement `NotificationWidget` to display a summary of saved items and a 2x2 grid of top sources.
    - Create `WidgetTheme` and `WidgetUtils` to support dynamic Material 3 theming, including AMOLED and expressive color schemes, for Glance widgets.
    - Register `NotificationWidgetReceiver` and configure `notification_widget_info.xml`.
    - Set up automated widget updates in `KmpOtakuApp` by observing the database count flow.
- **deps**: Add `androidx.glance` (v1.3.0-alpha02) dependencies for Android.