### PR TITLE
refactor: improve screensaver layout and orientation handling logic

### DIFF
--- a/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
+++ b/datastore/src/commonMain/kotlin/com/programmersbox/datastore/SettingsHandling.kt
@@ -206,6 +206,13 @@ class NewSettingsHandling(
     )
 
     @Composable
+    fun rememberScreensaverType() = preferences.rememberPreference(
+        key = { it.screensaverType },
+        update = { copy(screensaverType = it) },
+        defaultValue = ScreensaverType.Dashboard
+    )
+
+    @Composable
     fun rememberShowExpressiveness() = preferences.rememberPreference(
         key = { it.showExpressiveness },
         update = { copy(showExpressiveness = it) },

--- a/datastore/src/commonMain/proto/settings.proto
+++ b/datastore/src/commonMain/proto/settings.proto
@@ -35,6 +35,15 @@ message Settings {
   bool liquidGlassDepthEffect = 33;
   bool liquidGlassChromaticAberration = 34;
   BlurKind blurKind = 35;
+  ScreensaverType screensaverType = 36;
+}
+
+enum ScreensaverType {
+  Dashboard = 0;
+  CoverCarousel = 1;
+  HistoryFeed = 2;
+  StatsDashboard = 3;
+  CustomListRotation = 4;
 }
 
 enum BlurKind {

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/GenericInfo.android.kt
@@ -10,11 +10,14 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.programmersbox.kmpmodels.KmpItemModel
 import com.programmersbox.kmpuiviews.presentation.Screen
+import com.programmersbox.kmpuiviews.presentation.components.settings.CategoryGroupListItem
+import com.programmersbox.kmpuiviews.presentation.settings.ScreensaverTypeSettings
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import com.programmersbox.kmpuiviews.utils.DeepLinks
 import com.programmersbox.kmpuiviews.utils.composables.WidgetAddCard
 import com.programmersbox.kmpuiviews.utils.composables.widgetChecker
 import com.programmersbox.kmpuiviews.widget.notification.NotificationWidgetReceiver
+import org.koin.compose.koinInject
 
 actual interface PlatformGenericInfo : KmpGenericInfo {
     val deepLinkUri: String
@@ -51,6 +54,12 @@ actual interface PlatformGenericInfo : KmpGenericInfo {
                 widgetCheckerState = state.value,
                 description = "View saved notifications straight on your home screen!"
             )
+        }
+
+        layoutSettings {
+            CategoryGroupListItem {
+                item { ScreensaverTypeSettings(handling = koinInject()) }
+            }
         }
     }
 

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/di/ViewModelModule.android.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/di/ViewModelModule.android.kt
@@ -1,10 +1,18 @@
 package com.programmersbox.kmpuiviews.di
 
+import com.programmersbox.kmpuiviews.screensaver.CoverCarouselViewModel
+import com.programmersbox.kmpuiviews.screensaver.CustomListRotationViewModel
+import com.programmersbox.kmpuiviews.screensaver.HistoryFeedViewModel
 import com.programmersbox.kmpuiviews.screensaver.ScreensaverViewModel
+import com.programmersbox.kmpuiviews.screensaver.StatsDashboardViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 actual fun platformViewModels(): Module = module {
     viewModelOf(::ScreensaverViewModel)
+    viewModelOf(::CoverCarouselViewModel)
+    viewModelOf(::HistoryFeedViewModel)
+    viewModelOf(::StatsDashboardViewModel)
+    viewModelOf(::CustomListRotationViewModel)
 }

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/CustomSettings.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/CustomSettings.kt
@@ -1,0 +1,51 @@
+package com.programmersbox.kmpuiviews.presentation.settings
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Slideshow
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.ScreensaverType
+import com.programmersbox.kmpuiviews.presentation.components.settings.ListSetting
+import org.jetbrains.compose.resources.stringResource
+import otakuworld.kmpuiviews.generated.resources.Res
+import otakuworld.kmpuiviews.generated.resources.cancel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+fun ScreensaverTypeSettings(handling: NewSettingsHandling) {
+    var screensaverType by handling.rememberScreensaverType()
+
+    ListSetting(
+        settingTitle = { Text("Screensaver") },
+        settingIcon = { Icon(Icons.Default.Slideshow, null, modifier = Modifier.fillMaxSize()) },
+        value = screensaverType,
+        updateValue = { it, d ->
+            d.value = false
+            screensaverType = it
+        },
+        options = ScreensaverType.entries,
+        summaryValue = {
+            Text(
+                when (screensaverType) {
+                    ScreensaverType.Dashboard -> "Dashboard: Clock, battery, activity, and saved items."
+                    ScreensaverType.CoverCarousel -> "Cover Carousel: Full-screen rotating cover art."
+                    ScreensaverType.HistoryFeed -> "History Feed: Recently viewed items."
+                    ScreensaverType.StatsDashboard -> "Stats: Reading/watching activity totals."
+                    ScreensaverType.CustomListRotation -> "Custom Lists: Cycles through your custom lists."
+                }
+            )
+        },
+        confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(Res.string.cancel)) } },
+        dialogTitle = { Text("Screensaver") },
+        dialogIcon = { Icon(Icons.Default.Slideshow, null) },
+    )
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselScreen.kt
@@ -1,8 +1,8 @@
 package com.programmersbox.kmpuiviews.screensaver
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -55,8 +55,11 @@ fun CoverCarouselScreen(
         }
     }
 
-    Scaffold { _ ->
-        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+    Scaffold { padding ->
+        SensorRotatedLayout(
+            physicalOrientation = physicalOrientation,
+            modifier = Modifier.padding(padding)
+        ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 val item = items.getOrNull(currentIndex % items.size.coerceAtLeast(1))
                 if (item != null) {

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselScreen.kt
@@ -1,0 +1,117 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.favoritesdatabase.NotificationItem
+import com.programmersbox.kmpuiviews.utils.composables.imageloaders.ImageLoaderChoice
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.koin.compose.viewmodel.koinViewModel
+import kotlin.time.Duration.Companion.seconds
+
+private val CAROUSEL_INTERVAL = 10.seconds
+
+@Composable
+fun CoverCarouselScreen(
+    viewModel: CoverCarouselViewModel = koinViewModel(),
+) {
+    val items by viewModel.items.collectAsStateWithLifecycle()
+    val physicalOrientation by rememberPhysicalDeviceOrientation()
+
+    var currentIndex by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(items) {
+        if (items.isEmpty()) return@LaunchedEffect
+        while (isActive) {
+            delay(CAROUSEL_INTERVAL)
+            currentIndex = (currentIndex + 1) % items.size
+        }
+    }
+
+    Scaffold { _ ->
+        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                val item = items.getOrNull(currentIndex % items.size.coerceAtLeast(1))
+                if (item != null) {
+                    AnimatedContent(
+                        targetState = item,
+                        transitionSpec = { fadeIn(tween(1500)) togetherWith fadeOut(tween(1500)) },
+                        modifier = Modifier.fillMaxSize()
+                    ) { target ->
+                        KenBurnsCover(item = target)
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("Nothing saved yet", style = MaterialTheme.typography.headlineSmall)
+                    }
+                }
+
+                DateBatteryCard(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun KenBurnsCover(item: NotificationItem) {
+    val scale = remember(item.url) { Animatable(1f) }
+
+    LaunchedEffect(item.url) {
+        scale.snapTo(1f)
+        scale.animateTo(
+            targetValue = 1.15f,
+            animationSpec = tween(
+                durationMillis = CAROUSEL_INTERVAL.inWholeMilliseconds.toInt(),
+                easing = LinearEasing
+            )
+        )
+    }
+
+    ImageLoaderChoice(
+        imageUrl = item.imageUrl.orEmpty(),
+        name = item.notiTitle,
+        placeHolder = { rememberVectorPainter(Icons.Default.Settings) },
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
+            }
+    )
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselViewModel.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CoverCarouselViewModel.kt
@@ -1,0 +1,28 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.programmersbox.favoritesdatabase.ItemDao
+import com.programmersbox.favoritesdatabase.NotificationItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+class CoverCarouselViewModel(
+    db: ItemDao,
+) : ViewModel() {
+
+    val items: StateFlow<List<NotificationItem>>
+        field = MutableStateFlow<List<NotificationItem>>(emptyList())
+
+    init {
+        db
+            .getAllNotificationsFlow()
+            .onEach { list ->
+                items.update { list }
+            }
+            .launchIn(viewModelScope)
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
@@ -38,8 +39,11 @@ fun CustomListRotationScreen(
     val physicalOrientation by rememberPhysicalDeviceOrientation()
     val currentList = lists.getOrNull(viewModel.currentIndex)
 
-    Scaffold { _ ->
-        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+    Scaffold { padding ->
+        SensorRotatedLayout(
+            physicalOrientation = physicalOrientation,
+            modifier = Modifier.padding(padding)
+        ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
@@ -75,12 +79,20 @@ fun CustomListRotationScreen(
 
 @Composable
 private fun CustomListGrid(list: CustomList) {
+    val listState = rememberLazyGridState()
+
+    SlowScroll(
+        listState = listState,
+        animateScrollToItem = { listState.scrollToItem(it) }
+    )
+
     Card(
         shape = MaterialTheme.shapes.extraLarge,
         modifier = Modifier.fillMaxSize()
     ) {
         LazyVerticalGrid(
             columns = GridCells.Adaptive(ComposableUtils.IMAGE_WIDTH),
+            state = listState,
             verticalArrangement = Arrangement.spacedBy(4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationScreen.kt
@@ -1,0 +1,108 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.favoritesdatabase.CustomList
+import com.programmersbox.kmpuiviews.presentation.components.M3CoverCard2
+import com.programmersbox.kmpuiviews.utils.ComposableUtils
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun CustomListRotationScreen(
+    viewModel: CustomListRotationViewModel = koinViewModel(),
+) {
+    val lists by viewModel.lists.collectAsStateWithLifecycle()
+    val physicalOrientation by rememberPhysicalDeviceOrientation()
+    val currentList = lists.getOrNull(viewModel.currentIndex)
+
+    Scaffold { _ ->
+        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                DateBatteryCard()
+
+                AnimatedContent(
+                    targetState = currentList,
+                    modifier = Modifier.weight(1f)
+                ) { list ->
+                    if (list != null) {
+                        CustomListGrid(list = list)
+                    } else {
+                        Card(
+                            shape = MaterialTheme.shapes.extraLarge,
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text("No custom lists yet", style = MaterialTheme.typography.headlineSmall)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomListGrid(list: CustomList) {
+    Card(
+        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(ComposableUtils.IMAGE_WIDTH),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                Text(
+                    list.item.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            items(list.list) { info ->
+                M3CoverCard2(
+                    imageUrl = info.imageUrl,
+                    name = info.title,
+                    placeHolder = { rememberVectorPainter(Icons.Default.Settings) },
+                )
+            }
+        }
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationViewModel.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/CustomListRotationViewModel.kt
@@ -1,0 +1,50 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.programmersbox.favoritesdatabase.CustomList
+import com.programmersbox.favoritesdatabase.ListDao
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+class CustomListRotationViewModel(
+    listDao: ListDao,
+) : ViewModel() {
+
+    val lists: StateFlow<List<CustomList>>
+        field = MutableStateFlow<List<CustomList>>(emptyList())
+
+    var currentIndex by mutableIntStateOf(0)
+
+    init {
+        listDao
+            .getAllLists()
+            .onEach { list ->
+                lists.update { list }
+                if (currentIndex >= list.size) currentIndex = 0
+            }
+            .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            while (isActive) {
+                delay(ROTATION_INTERVAL)
+                val size = lists.value.size
+                if (size > 0) currentIndex = (currentIndex + 1) % size
+            }
+        }
+    }
+
+    companion object {
+        private val ROTATION_INTERVAL = 20.seconds
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedScreen.kt
@@ -1,0 +1,133 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.favoritesdatabase.RecentModel
+import com.programmersbox.kmpuiviews.DateTimeFormatHandler
+import com.programmersbox.kmpuiviews.presentation.components.M3CoverCard2
+import com.programmersbox.kmpuiviews.utils.DateTimeFormatScreensaverItem
+import com.programmersbox.kmpuiviews.utils.toLocalDateTime
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun HistoryFeedScreen(
+    viewModel: HistoryFeedViewModel = koinViewModel(),
+) {
+    val recentlyViewed by viewModel.recentlyViewed.collectAsStateWithLifecycle()
+    val physicalOrientation by rememberPhysicalDeviceOrientation()
+
+    Scaffold { _ ->
+        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                DateBatteryCard()
+
+                HistoryFeedList(
+                    list = recentlyViewed,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryFeedList(
+    list: List<RecentModel>,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+
+    SlowScroll(
+        listState = listState,
+        animateScrollToItem = { listState.animateScrollToItem(it) }
+    )
+
+    Card(
+        shape = MaterialTheme.shapes.extraLarge,
+        modifier = modifier
+    ) {
+        LazyColumn(
+            state = listState,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            item {
+                Text(
+                    "Recently Viewed",
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            if (list.isEmpty()) {
+                item { Text("Nothing viewed yet") }
+            }
+
+            items(list) { recent -> HistoryFeedRow(recent) }
+        }
+    }
+}
+
+@Composable
+private fun HistoryFeedRow(recent: RecentModel) {
+    val dateTimeFormatHandler: DateTimeFormatHandler = koinInject()
+    val is24Time = dateTimeFormatHandler.is24Time()
+    val dateFormat = remember(is24Time) {
+        DateTimeFormatScreensaverItem(is24Time)
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        M3CoverCard2(
+            imageUrl = recent.imageUrl,
+            name = recent.title,
+            placeHolder = { rememberVectorPainter(Icons.Default.Settings) },
+        )
+
+        Column {
+            Text(
+                recent.title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1
+            )
+            Text(
+                dateFormat.format(recent.timestamp.toLocalDateTime()),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedScreen.kt
@@ -1,14 +1,14 @@
 package com.programmersbox.kmpuiviews.screensaver
 
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
@@ -39,8 +39,11 @@ fun HistoryFeedScreen(
     val recentlyViewed by viewModel.recentlyViewed.collectAsStateWithLifecycle()
     val physicalOrientation by rememberPhysicalDeviceOrientation()
 
-    Scaffold { _ ->
-        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+    Scaffold { padding ->
+        SensorRotatedLayout(
+            physicalOrientation = physicalOrientation,
+            modifier = Modifier.padding(padding)
+        ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedViewModel.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/HistoryFeedViewModel.kt
@@ -1,0 +1,28 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.programmersbox.favoritesdatabase.HistoryDao
+import com.programmersbox.favoritesdatabase.RecentModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+class HistoryFeedViewModel(
+    historyDao: HistoryDao,
+) : ViewModel() {
+
+    val recentlyViewed: StateFlow<List<RecentModel>>
+        field = MutableStateFlow<List<RecentModel>>(emptyList())
+
+    init {
+        historyDao
+            .getRecentlyViewed()
+            .onEach { list ->
+                recentlyViewed.update { list.sortedByDescending { item -> item.timestamp } }
+            }
+            .launchIn(viewModelScope)
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/ScreensaverScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/ScreensaverScreen.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.ScreensaverType
 import com.programmersbox.favoritesdatabase.NotificationItem
 import com.programmersbox.kmpuiviews.DateTimeFormatHandler
 import com.programmersbox.kmpuiviews.presentation.components.M3CoverCard2
@@ -80,7 +82,21 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
-fun ScreensaverScreen(
+fun ScreensaverScreen() {
+    val settingsHandling: NewSettingsHandling = koinInject()
+    val screensaverType by settingsHandling.rememberScreensaverType()
+
+    when (screensaverType) {
+        ScreensaverType.Dashboard -> DashboardScreensaverScreen()
+        ScreensaverType.CoverCarousel -> CoverCarouselScreen()
+        ScreensaverType.HistoryFeed -> HistoryFeedScreen()
+        ScreensaverType.StatsDashboard -> StatsDashboardScreen()
+        ScreensaverType.CustomListRotation -> CustomListRotationScreen()
+    }
+}
+
+@Composable
+private fun DashboardScreensaverScreen(
     viewModel: ScreensaverViewModel = koinViewModel(),
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
@@ -249,7 +265,7 @@ private fun InfoCard(
 }
 
 @Composable
-private fun DateBatteryCard(
+fun DateBatteryCard(
     modifier: Modifier = Modifier,
 ) {
     val timeRemaining by rememberBatteryInfo()

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/ScreensaverScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/ScreensaverScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -62,6 +61,7 @@ import com.programmersbox.favoritesdatabase.NotificationItem
 import com.programmersbox.kmpuiviews.DateTimeFormatHandler
 import com.programmersbox.kmpuiviews.presentation.components.M3CoverCard2
 import com.programmersbox.kmpuiviews.utils.ComposableUtils
+import com.programmersbox.kmpuiviews.utils.CustomAdaptive
 import com.programmersbox.kmpuiviews.utils.DateTimeFormatScreensaverItem
 import com.programmersbox.kmpuiviews.utils.toLocalDateTime
 import kotlinx.coroutines.channels.awaitClose
@@ -85,8 +85,11 @@ fun ScreensaverScreen(
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
     val physicalOrientation by rememberPhysicalDeviceOrientation()
-    Scaffold { _ ->
-        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+    Scaffold { padding ->
+        SensorRotatedLayout(
+            physicalOrientation = physicalOrientation,
+            modifier = Modifier.padding(padding)
+        ) {
             SharedTransitionLayout {
                 val boxes = remember {
                     movableContentOf { modifier: Modifier, animatedVisibilityScope: AnimatedVisibilityScope ->
@@ -182,7 +185,7 @@ private fun ItemsCard(
 
     SlowScroll(
         listState = listState,
-        animateScrollToItem = { listState.animateScrollToItem(it) }
+        animateScrollToItem = { listState.scrollToItem(it) }
     )
 
     Card(
@@ -190,7 +193,7 @@ private fun ItemsCard(
         modifier = modifier.animateContentSize()
     ) {
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(ComposableUtils.IMAGE_WIDTH),
+            columns = CustomAdaptive(ComposableUtils.IMAGE_WIDTH),
             state = listState,
             verticalArrangement = Arrangement.spacedBy(4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -202,6 +205,7 @@ private fun ItemsCard(
         ) {
             item(
                 span = { GridItemSpan(maxLineSpan) },
+                contentType = "title"
             ) {
                 Text(
                     "Saved For Later",
@@ -213,7 +217,11 @@ private fun ItemsCard(
                 )
             }
 
-            items(list) {
+            items(
+                items = list,
+                contentType = { _ -> "listItem" },
+                key = { it.url }
+            ) {
                 M3CoverCard2(
                     imageUrl = it.imageUrl.orEmpty(),
                     name = it.notiTitle,
@@ -486,6 +494,8 @@ private fun physicalDeviceOrientationFlow(context: Context): Flow<PhysicalOrient
         override fun onOrientationChanged(degrees: Int) {
             if (degrees == ORIENTATION_UNKNOWN) return // Device is flat
 
+            android.util.Log.d("OrientationSensor", "Raw Hardware Degrees: $degrees")
+
             val newOrientation = when (degrees) {
                 in 45..134 -> PhysicalOrientation.LANDSCAPE_LEFT
                 in 135..224 -> PhysicalOrientation.REVERSE_PORTRAIT
@@ -525,23 +535,36 @@ fun SensorRotatedLayout(
         PhysicalOrientation.LANDSCAPE_RIGHT -> 90f
     }
 
-    val animatedRotation by animateFloatAsState(
-        targetValue = targetRotation,
-        animationSpec = tween(durationMillis = 500),
-        label = "rotation"
-    )
-
     BoxWithConstraints(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        val isLandscape = targetRotation % 180 != 0f
+        // 1. Detect if the OS actually rotated the window to landscape
+        val isWindowLandscape = maxWidth > maxHeight
+        // 2. Detect if the hardware sensor wants a landscape layout
+        val isSensorLandscape = targetRotation % 180 != 0f
 
-        // Swap width and height based on orientation
-        val targetWidth = if (isLandscape) maxHeight else maxWidth
-        val targetHeight = if (isLandscape) maxWidth else maxHeight
+        // 3. If the window and sensor agree, the OS already did the work.
+        // We only apply rotation if the OS is locked in portrait.
+        val finalRotation = if (isSensorLandscape && isWindowLandscape) {
+            0f
+        } else {
+            targetRotation
+        }
 
-        // Animate the size change so SharedTransitionLayout doesn't jump
+        // 4. Only swap dimensions if the physical window aspect ratio
+        // doesn't match the sensor's intended orientation.
+        val needsDimensionSwap = isSensorLandscape != isWindowLandscape
+
+        val targetWidth = if (needsDimensionSwap) maxHeight else maxWidth
+        val targetHeight = if (needsDimensionSwap) maxWidth else maxHeight
+
+        val animatedRotation by animateFloatAsState(
+            targetValue = finalRotation,
+            animationSpec = tween(durationMillis = 500),
+            label = "rotation"
+        )
+
         val animatedWidth by animateDpAsState(
             targetValue = targetWidth,
             animationSpec = tween(durationMillis = 500),

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardScreen.kt
@@ -1,0 +1,68 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun StatsDashboardScreen(
+    viewModel: StatsDashboardViewModel = koinViewModel(),
+) {
+    val physicalOrientation by rememberPhysicalDeviceOrientation()
+
+    Scaffold { _ ->
+        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                DateBatteryCard()
+
+                Card(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.SpaceEvenly,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(24.dp)
+                    ) {
+                        Text("Stats", style = MaterialTheme.typography.headlineSmall)
+                        StatRow("Time Spent", viewModel.activity)
+                        StatRow("Favorites", viewModel.favoritesCount.toString())
+                        StatRow("Recently Viewed", viewModel.recentHistoryCount.toString())
+                        StatRow("Custom Lists", viewModel.customListsCount.toString())
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(label, style = MaterialTheme.typography.titleMedium)
+        Text(value, style = MaterialTheme.typography.titleMedium)
+    }
+}

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardScreen.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardScreen.kt
@@ -22,8 +22,11 @@ fun StatsDashboardScreen(
 ) {
     val physicalOrientation by rememberPhysicalDeviceOrientation()
 
-    Scaffold { _ ->
-        SensorRotatedLayout(physicalOrientation = physicalOrientation) {
+    Scaffold { padding ->
+        SensorRotatedLayout(
+            physicalOrientation = physicalOrientation,
+            modifier = Modifier.padding(padding)
+        ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier

--- a/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardViewModel.kt
+++ b/kmpuiviews/src/androidMain/kotlin/com/programmersbox/kmpuiviews/screensaver/StatsDashboardViewModel.kt
@@ -1,0 +1,55 @@
+package com.programmersbox.kmpuiviews.screensaver
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.programmersbox.favoritesdatabase.ActivityDao
+import com.programmersbox.favoritesdatabase.HistoryDao
+import com.programmersbox.favoritesdatabase.ItemDao
+import com.programmersbox.favoritesdatabase.ListDao
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlin.time.Duration.Companion.seconds
+
+class StatsDashboardViewModel(
+    db: ItemDao,
+    activityDao: ActivityDao,
+    historyDao: HistoryDao,
+    listDao: ListDao,
+) : ViewModel() {
+
+    var activity by mutableStateOf("")
+
+    var favoritesCount by mutableIntStateOf(0)
+
+    var recentHistoryCount by mutableIntStateOf(0)
+
+    var customListsCount by mutableIntStateOf(0)
+
+    init {
+        activityDao
+            .observeActivity()
+            .onEach {
+                activity = it?.cumulativeSeconds?.seconds?.toString() ?: ""
+            }
+            .launchIn(viewModelScope)
+
+        db
+            .getAllFavoritesCount()
+            .onEach { favoritesCount = it }
+            .launchIn(viewModelScope)
+
+        historyDao
+            .getAllRecentHistoryCount()
+            .onEach { recentHistoryCount = it }
+            .launchIn(viewModelScope)
+
+        listDao
+            .getAllListsCount()
+            .onEach { customListsCount = it }
+            .launchIn(viewModelScope)
+    }
+}

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/behavior/LayoutScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/behavior/LayoutScreen.kt
@@ -12,6 +12,7 @@ import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
 import com.programmersbox.kmpuiviews.presentation.settings.general.DetailPaneSettings
 import com.programmersbox.kmpuiviews.presentation.settings.general.GridTypeSettings
 import com.programmersbox.kmpuiviews.presentation.settings.general.NavigationBarSettings
+import com.programmersbox.kmpuiviews.presentation.settings.general.ScreensaverTypeSettings
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import org.koin.compose.koinInject
 
@@ -33,6 +34,10 @@ fun LayoutScreen(
 
         CategoryGroupListItem {
             item { NavigationBarSettings(handling = handling) }
+        }
+
+        CategoryGroupListItem {
+            item { ScreensaverTypeSettings(handling = handling) }
         }
 
         composeSettingsDsl.layoutSettings()

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/behavior/LayoutScreen.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/behavior/LayoutScreen.kt
@@ -6,13 +6,11 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import com.programmersbox.datastore.NewSettingsHandling
-import com.programmersbox.kmpuiviews.presentation.components.item
 import com.programmersbox.kmpuiviews.presentation.components.settings.CategoryGroupListItem
 import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
 import com.programmersbox.kmpuiviews.presentation.settings.general.DetailPaneSettings
 import com.programmersbox.kmpuiviews.presentation.settings.general.GridTypeSettings
 import com.programmersbox.kmpuiviews.presentation.settings.general.NavigationBarSettings
-import com.programmersbox.kmpuiviews.presentation.settings.general.ScreensaverTypeSettings
 import com.programmersbox.kmpuiviews.utils.ComposeSettingsDsl
 import org.koin.compose.koinInject
 
@@ -34,10 +32,6 @@ fun LayoutScreen(
 
         CategoryGroupListItem {
             item { NavigationBarSettings(handling = handling) }
-        }
-
-        CategoryGroupListItem {
-            item { ScreensaverTypeSettings(handling = handling) }
         }
 
         composeSettingsDsl.layoutSettings()

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/GeneralSettings.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/GeneralSettings.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Slideshow
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -52,6 +53,7 @@ import com.programmersbox.datastore.DataStoreHandling
 import com.programmersbox.datastore.GridChoice
 import com.programmersbox.datastore.MiddleNavigationAction
 import com.programmersbox.datastore.NewSettingsHandling
+import com.programmersbox.datastore.ScreensaverType
 import com.programmersbox.datastore.asState
 import com.programmersbox.datastore.rememberFloatingNavigation
 import com.programmersbox.kmpuiviews.presentation.Screen
@@ -200,6 +202,37 @@ fun ColorBlindTypeSettings(handling: NewSettingsHandling) {
         confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(Res.string.cancel)) } },
         dialogTitle = { Text("Color Blindness") },
         dialogIcon = { Icon(Icons.Default.ColorLens, null) },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+fun ScreensaverTypeSettings(handling: NewSettingsHandling) {
+    var screensaverType by handling.rememberScreensaverType()
+
+    ListSetting(
+        settingTitle = { Text("Screensaver") },
+        settingIcon = { Icon(Icons.Default.Slideshow, null, modifier = Modifier.fillMaxSize()) },
+        value = screensaverType,
+        updateValue = { it, d ->
+            d.value = false
+            screensaverType = it
+        },
+        options = ScreensaverType.entries,
+        summaryValue = {
+            Text(
+                when (screensaverType) {
+                    ScreensaverType.Dashboard -> "Dashboard: Clock, battery, activity, and saved items."
+                    ScreensaverType.CoverCarousel -> "Cover Carousel: Full-screen rotating cover art."
+                    ScreensaverType.HistoryFeed -> "History Feed: Recently viewed items."
+                    ScreensaverType.StatsDashboard -> "Stats: Reading/watching activity totals."
+                    ScreensaverType.CustomListRotation -> "Custom Lists: Cycles through your custom lists."
+                }
+            )
+        },
+        confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(Res.string.cancel)) } },
+        dialogTitle = { Text("Screensaver") },
+        dialogIcon = { Icon(Icons.Default.Slideshow, null) },
     )
 }
 

--- a/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/GeneralSettings.kt
+++ b/kmpuiviews/src/commonMain/kotlin/com/programmersbox/kmpuiviews/presentation/settings/general/GeneralSettings.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Slideshow
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -53,7 +52,6 @@ import com.programmersbox.datastore.DataStoreHandling
 import com.programmersbox.datastore.GridChoice
 import com.programmersbox.datastore.MiddleNavigationAction
 import com.programmersbox.datastore.NewSettingsHandling
-import com.programmersbox.datastore.ScreensaverType
 import com.programmersbox.datastore.asState
 import com.programmersbox.datastore.rememberFloatingNavigation
 import com.programmersbox.kmpuiviews.presentation.Screen
@@ -68,7 +66,6 @@ import com.programmersbox.kmpuiviews.presentation.components.visibleName
 import com.programmersbox.kmpuiviews.presentation.settings.SettingsScaffold
 import com.programmersbox.kmpuiviews.utils.LocalNavActions
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 import otakuworld.kmpuiviews.generated.resources.Res
 import otakuworld.kmpuiviews.generated.resources.cancel
 import otakuworld.kmpuiviews.generated.resources.general_menu_title
@@ -202,37 +199,6 @@ fun ColorBlindTypeSettings(handling: NewSettingsHandling) {
         confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(Res.string.cancel)) } },
         dialogTitle = { Text("Color Blindness") },
         dialogIcon = { Icon(Icons.Default.ColorLens, null) },
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
-@Composable
-fun ScreensaverTypeSettings(handling: NewSettingsHandling) {
-    var screensaverType by handling.rememberScreensaverType()
-
-    ListSetting(
-        settingTitle = { Text("Screensaver") },
-        settingIcon = { Icon(Icons.Default.Slideshow, null, modifier = Modifier.fillMaxSize()) },
-        value = screensaverType,
-        updateValue = { it, d ->
-            d.value = false
-            screensaverType = it
-        },
-        options = ScreensaverType.entries,
-        summaryValue = {
-            Text(
-                when (screensaverType) {
-                    ScreensaverType.Dashboard -> "Dashboard: Clock, battery, activity, and saved items."
-                    ScreensaverType.CoverCarousel -> "Cover Carousel: Full-screen rotating cover art."
-                    ScreensaverType.HistoryFeed -> "History Feed: Recently viewed items."
-                    ScreensaverType.StatsDashboard -> "Stats: Reading/watching activity totals."
-                    ScreensaverType.CustomListRotation -> "Custom Lists: Cycles through your custom lists."
-                }
-            )
-        },
-        confirmText = { TextButton(onClick = { it.value = false }) { Text(stringResource(Res.string.cancel)) } },
-        dialogTitle = { Text("Screensaver") },
-        dialogIcon = { Icon(Icons.Default.Slideshow, null) },
     )
 }
 


### PR DESCRIPTION
- Update `Scaffold` to apply content padding to `SensorRotatedLayout`.
- Refine `SensorRotatedLayout` logic to handle cases where the OS and hardware sensor orientations already match, preventing redundant rotations.
- Update `LazyVerticalGrid` to use `CustomAdaptive` columns instead of `GridCells.Adaptive`.
- Improve grid performance by adding `key` and `contentType` to list items.
- Change `SlowScroll` to use `scrollToItem` for more immediate positioning during automated scrolling.
- Add debug logging for raw hardware orientation degrees in `OrientationEventListener`.